### PR TITLE
Feature/add correct incorrect metrics

### DIFF
--- a/integration_tests/data/expected/expected_sample_data_z_score.csv
+++ b/integration_tests/data/expected/expected_sample_data_z_score.csv
@@ -73,3 +73,7 @@ table_name,column_name,metric,z_score_value,last_value,last_avg,last_stddev,time
 """postgres"".""dq_raw"".""sample_with_anomaly""","value1","nulls_percent",0,0,0,0,"2021-05-03 00:00:00",86400
 """postgres"".""dq_raw"".""sample_with_anomaly""","value2","nulls_percent",0,0,0,0,"2021-05-03 00:00:00",86400
 """postgres"".""dq_raw"".""sample_table""","event_type","regexp_test",0,4,4,0,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","correct_count",-0.707106781086547,0,0.5,0.707106781186548,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","correct_percent",-0.707106781182548,0,12.5,17.6776695296637,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","incorrect_count",0.707106781086547,4,3.5,0.707106781186548,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","incorrect_percent",0.707106781182548,100,87.5,17.6776695296637,"2021-05-03 00:00:00",86400

--- a/integration_tests/data/expected/expected_sample_data_z_score.csv
+++ b/integration_tests/data/expected/expected_sample_data_z_score.csv
@@ -59,3 +59,4 @@ table_name,column_name,metric,z_score_value,last_value,last_avg,last_stddev,time
 """postgres"".""dq_raw"".""sample_with_anomaly""",event_type,nulls_count,0,0,0,0,2021-05-03 00:00:00,86400
 """postgres"".""dq_raw"".""sample_with_anomaly""",value1,nulls_count,0,0,0,0,2021-05-03 00:00:00,86400
 """postgres"".""dq_raw"".""sample_with_anomaly""","",row_count,0,1,1,0,2021-05-03 00:00:00,86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","regexp_test",0,4,4,0,"2021-05-03 00:00:00",86400

--- a/integration_tests/data/expected/expected_sample_data_z_score.csv
+++ b/integration_tests/data/expected/expected_sample_data_z_score.csv
@@ -72,8 +72,8 @@ table_name,column_name,metric,z_score_value,last_value,last_avg,last_stddev,time
 """postgres"".""dq_raw"".""sample_with_anomaly""","event_type","missing_percent",0,0,0,0,"2021-05-03 00:00:00",86400
 """postgres"".""dq_raw"".""sample_with_anomaly""","value1","nulls_percent",0,0,0,0,"2021-05-03 00:00:00",86400
 """postgres"".""dq_raw"".""sample_with_anomaly""","value2","nulls_percent",0,0,0,0,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","regexp_test",0,4,4,0,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","correct_count",-0.707106781086547,0,0.5,0.707106781186548,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","correct_percent",-0.707106781182548,0,12.5,17.6776695296637,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","incorrect_count",0.707106781086547,4,3.5,0.707106781186548,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","incorrect_percent",0.707106781182548,100,87.5,17.6776695296637,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","regex_test",0,4,4,0,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","match_regex",-0.707106781086547,0,0.5,0.707106781186548,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","match_regex_percent",-0.707106781182548,0,12.5,17.6776695296637,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","not_match_regex",0.707106781086547,4,3.5,0.707106781186548,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","not_match_regex_percent",0.707106781182548,100,87.5,17.6776695296637,"2021-05-03 00:00:00",86400

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -29,6 +29,14 @@ vars:
               event_type:
                 - regexp_test:
                     regexp: ([A-Za-z0-9]+)
+                - correct_count:
+                    regexp: ^sell
+                - correct_percent:
+                    regexp: ^sell
+                - incorrect_count:
+                    regexp: ^buy
+                - incorrect_percent:
+                    regexp: ^buy
 
         - name: sample_with_anomaly
           time_filter: creation_time

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -25,6 +25,10 @@ vars:
           metrics:
             table:
               - my_custom_table_metric # my own custom metric
+            column:
+              event_type:
+                - regexp_test:
+                    regexp: ([A-Za-z0-9]+)
 
         - name: sample_with_anomaly
           time_filter: creation_time

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -27,16 +27,16 @@ vars:
               - my_custom_table_metric # my own custom metric
             column:
               event_type:
-                - regexp_test:
-                    regexp: ([A-Za-z0-9]+)
-                - correct_count:
-                    regexp: ^sell
-                - correct_percent:
-                    regexp: ^sell
-                - incorrect_count:
-                    regexp: ^buy
-                - incorrect_percent:
-                    regexp: ^buy
+                - regex_test:
+                    regex: ([A-Za-z0-9]+)
+                - match_regex:
+                    regex: ^sell
+                - match_regex_percent:
+                    regex: ^sell
+                - not_match_regex:
+                    regex: ^buy
+                - not_match_regex_percent:
+                    regex: ^buy
 
         - name: sample_with_anomaly
           time_filter: creation_time

--- a/integration_tests/macros/my_metrics.sql
+++ b/integration_tests/macros/my_metrics.sql
@@ -29,14 +29,10 @@
 {% endmacro %}
 
 {% macro regexp_test(column_name, config) %}
-    {{ adapter.dispatch('regexp_test', project_name)(column_name, config) }}
-{% endmacro %}
-
-{% macro default__regexp_test(column_name, config) %}
     {% set pattern = config.get('regexp') %}
     coalesce(
         sum(
-            case when {{column_name}} ~ '{{pattern}}'
+            case when {{ re_data.regexp_match_expression(column_name, pattern) }}
                 then 1
             else 0
             end
@@ -44,26 +40,3 @@
     )
 {% endmacro %}
 
-{% macro bigquery__regexp_test(column_name, config) %}
-    {% set pattern = config.get('regexp') %}
-    coalesce(
-        sum(
-            case when regexp_contains({{column_name}}, '{{pattern}}')
-                then 1
-            else 0
-            end
-        ), 0
-    )
-{% endmacro %}
-
-{% macro snowflake__regexp_test(column_name, config) %}
-    {% set pattern = config.get('regexp') %}
-    coalesce(
-        sum(
-            case when regexp_like({{column_name | upper}}, '{{pattern}}')
-                then 1
-            else 0
-            end
-        ), 0
-    )
-{% endmacro %}

--- a/integration_tests/macros/my_metrics.sql
+++ b/integration_tests/macros/my_metrics.sql
@@ -3,7 +3,7 @@
 {% endmacro %}
 
 
-{% macro re_data_metric_buy_count(time_column) %}
+{% macro re_data_metric_buy_count(time_column, config) %}
     coalesce(
         sum(
             case when event_type = 'buy'
@@ -14,7 +14,7 @@
     )
 {% endmacro %}
 
-{% macro re_data_metric_my_custom_table_metric(time_column) %}
+{% macro re_data_metric_my_custom_table_metric(time_column, config) %}
     1000
 {% endmacro %}
 

--- a/integration_tests/macros/my_metrics.sql
+++ b/integration_tests/macros/my_metrics.sql
@@ -1,9 +1,9 @@
-{% macro re_data_metric_diff(column_name, config) %}
+{% macro re_data_metric_diff(column_name) %}
     max({{column_name}}) - min({{column_name}})
 {% endmacro %}
 
 
-{% macro re_data_metric_buy_count(time_column, config) %}
+{% macro re_data_metric_buy_count(time_column) %}
     coalesce(
         sum(
             case when event_type = 'buy'
@@ -14,12 +14,12 @@
     )
 {% endmacro %}
 
-{% macro re_data_metric_my_custom_table_metric(time_column, config) %}
+{% macro re_data_metric_my_custom_table_metric(time_column) %}
     1000
 {% endmacro %}
 
 
-{% macro re_data_metric_distinct_count(column_name, config) %}
+{% macro re_data_metric_distinct_count(column_name) %}
     count(distinct( {{column_name}} ))
 
 {% endmacro %}

--- a/integration_tests/macros/my_metrics.sql
+++ b/integration_tests/macros/my_metrics.sql
@@ -24,15 +24,15 @@
 
 {% endmacro %}
 
-{% macro re_data_metric_regexp_test(column_name, config) %}
-    {{ regexp_test(column_name, config) }}
+{% macro re_data_metric_regex_test(column_name, config) %}
+    {{ regex_test(column_name, config) }}
 {% endmacro %}
 
-{% macro regexp_test(column_name, config) %}
-    {% set pattern = config.get('regexp') %}
+{% macro regex_test(column_name, config) %}
+    {% set pattern = config.get('regex') %}
     coalesce(
         sum(
-            case when {{ re_data.regexp_match_expression(column_name, pattern) }}
+            case when {{ re_data.regex_match_expression(column_name, pattern) }}
                 then 1
             else 0
             end

--- a/integration_tests/macros/my_metrics.sql
+++ b/integration_tests/macros/my_metrics.sql
@@ -25,14 +25,45 @@
 {% endmacro %}
 
 {% macro re_data_metric_regexp_test(column_name, config) %}
+    {{ regexp_test(column_name, config) }}
+{% endmacro %}
+
+{% macro regexp_test(column_name, config) %}
+    {{ adapter.dispatch('regexp_test', project_name)(column_name, config) }}
+{% endmacro %}
+
+{% macro default__regexp_test(column_name, config) %}
     {% set pattern = config.get('regexp') %}
     coalesce(
         sum(
-            case when event_type ~ '{{pattern}}'
+            case when {{column_name}} ~ '{{pattern}}'
                 then 1
             else 0
             end
         ), 0
     )
+{% endmacro %}
 
+{% macro bigquery__regexp_test(column_name, config) %}
+    {% set pattern = config.get('regexp') %}
+    coalesce(
+        sum(
+            case when regexp_contains({{column_name}}, '{{pattern}}')
+                then 1
+            else 0
+            end
+        ), 0
+    )
+{% endmacro %}
+
+{% macro snowflake__regexp_test(column_name, config) %}
+    {% set pattern = config.get('regexp') %}
+    coalesce(
+        sum(
+            case when regexp_like({{column_name | upper}}, '{{pattern}}')
+                then 1
+            else 0
+            end
+        ), 0
+    )
 {% endmacro %}

--- a/integration_tests/macros/my_metrics.sql
+++ b/integration_tests/macros/my_metrics.sql
@@ -1,4 +1,4 @@
-{% macro re_data_metric_diff(column_name) %}
+{% macro re_data_metric_diff(column_name, config) %}
     max({{column_name}}) - min({{column_name}})
 {% endmacro %}
 
@@ -19,7 +19,20 @@
 {% endmacro %}
 
 
-{% macro re_data_metric_distinct_count(column_name) %}
+{% macro re_data_metric_distinct_count(column_name, config) %}
     count(distinct( {{column_name}} ))
+
+{% endmacro %}
+
+{% macro re_data_metric_regexp_test(column_name, config) %}
+    {% set pattern = config.get('regexp') %}
+    coalesce(
+        sum(
+            case when event_type ~ '{{pattern}}'
+                then 1
+            else 0
+            end
+        ), 0
+    )
 
 {% endmacro %}

--- a/macros/metrics/base/build_in/column_default.sql
+++ b/macros/metrics/base/build_in/column_default.sql
@@ -64,10 +64,10 @@
     {{ percentage_formula(re_data_metric_missing_count(column_name), re_data_metric_row_count()) }}
 {% endmacro %}
 
-{% macro re_data_metric_regexp_count(column_name, pattern) %}
+{% macro re_data_metric_regex_count(column_name, pattern) %}
     coalesce(
         sum(
-            case when {{ regexp_match_expression(column_name, pattern) }}
+            case when {{ regex_match_expression(column_name, pattern) }}
                 then 1
             else 0
             end
@@ -75,20 +75,20 @@
     )
 {% endmacro %}
 
-{% macro re_data_metric_correct_count(column_name, config) %}
-    {% set pattern = config.get('regexp') %}
-    {{ re_data_metric_regexp_count(column_name, pattern) }}
+{% macro re_data_metric_match_regex(column_name, config) %}
+    {% set pattern = config.get('regex') %}
+    {{ re_data_metric_regex_count(column_name, pattern) }}
 {% endmacro %}
 
-{% macro re_data_metric_correct_percent(column_name, config) %}
-    {{ percentage_formula(re_data_metric_correct_count(column_name, config), re_data_metric_row_count()) }}
+{% macro re_data_metric_match_regex_percent(column_name, config) %}
+    {{ percentage_formula(re_data_metric_match_regex(column_name, config), re_data_metric_row_count()) }}
 {% endmacro %}
 
-{% macro re_data_metric_incorrect_count(column_name, config) %}
-    {% set pattern = config.get('regexp') %}
-    {{ re_data_metric_regexp_count(column_name, pattern) }}
+{% macro re_data_metric_not_match_regex(column_name, config) %}
+    {% set pattern = config.get('regex') %}
+    {{ re_data_metric_regex_count(column_name, pattern) }}
 {% endmacro %}
 
-{% macro re_data_metric_incorrect_percent(column_name, config) %}
-    {{ percentage_formula(re_data_metric_incorrect_count(column_name, config), re_data_metric_row_count()) }}
+{% macro re_data_metric_not_match_regex_percent(column_name, config) %}
+    {{ percentage_formula(re_data_metric_not_match_regex(column_name, config), re_data_metric_row_count()) }}
 {% endmacro %}

--- a/macros/metrics/base/build_in/column_default.sql
+++ b/macros/metrics/base/build_in/column_default.sql
@@ -1,37 +1,37 @@
 
-{% macro re_data_metric_max(column_name, config) %}
+{% macro re_data_metric_max(column_name) %}
     max({{column_name}})
 {% endmacro %}
 
-{% macro re_data_metric_min(column_name, config) %}
+{% macro re_data_metric_min(column_name) %}
     min({{column_name}})
 {% endmacro %}
 
-{% macro re_data_metric_avg(column_name, config) %}
+{% macro re_data_metric_avg(column_name) %}
     avg(cast ({{column_name}} as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_stddev(column_name, config) %}
+{% macro re_data_metric_stddev(column_name) %}
     stddev(cast ( {{column_name}} as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_variance(column_name, config) %}
+{% macro re_data_metric_variance(column_name) %}
     variance(cast ( {{column_name}} as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_max_length(column_name, config) %}
+{% macro re_data_metric_max_length(column_name) %}
     max(length({{column_name}}))
 {% endmacro %}
 
-{% macro re_data_metric_min_length(column_name, config) %}
+{% macro re_data_metric_min_length(column_name) %}
     min(length({{column_name}}))
 {% endmacro %}
 
-{% macro re_data_metric_avg_length(column_name, config) %}
+{% macro re_data_metric_avg_length(column_name) %}
     avg(cast (length( {{column_name}} ) as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_nulls_count(column_name, config) %}
+{% macro re_data_metric_nulls_count(column_name) %}
     coalesce(
         sum(
             case when {{column_name}} is null
@@ -42,7 +42,7 @@
     )
 {% endmacro %}
 
-{% macro re_data_metric_missing_count(column_name, config) %}
+{% macro re_data_metric_missing_count(column_name) %}
     coalesce(
         sum(
             case 
@@ -56,10 +56,10 @@
     )
 {% endmacro %}
 
-{% macro re_data_metric_nulls_percent(column_name, config) %}
+{% macro re_data_metric_nulls_percent(column_name) %}
     {{ re_data_metric_nulls_count(column_name) }} / nullif({{ re_data_metric_row_count() }}, 0) * 100
 {% endmacro %}
 
-{% macro re_data_metric_missing_percent(column_name, config) %}
+{% macro re_data_metric_missing_percent(column_name) %}
     {{ re_data_metric_missing_count(column_name) }} / nullif({{ re_data_metric_row_count() }}, 0) * 100
 {% endmacro %}

--- a/macros/metrics/base/build_in/column_default.sql
+++ b/macros/metrics/base/build_in/column_default.sql
@@ -57,9 +57,38 @@
 {% endmacro %}
 
 {% macro re_data_metric_nulls_percent(column_name) %}
-    {{ re_data_metric_nulls_count(column_name) }} / nullif({{ re_data_metric_row_count() }}, 0) * 100
+    {{ percentage_formula(re_data_metric_nulls_count(column_name), re_data_metric_row_count()) }}
 {% endmacro %}
 
 {% macro re_data_metric_missing_percent(column_name) %}
-    {{ re_data_metric_missing_count(column_name) }} / nullif({{ re_data_metric_row_count() }}, 0) * 100
+    {{ percentage_formula(re_data_metric_missing_count(column_name), re_data_metric_row_count()) }}
+{% endmacro %}
+
+{% macro re_data_metric_regexp_count(column_name, pattern) %}
+    coalesce(
+        sum(
+            case when {{ regexp_match_expression(column_name, pattern) }}
+                then 1
+            else 0
+            end
+        ), 0
+    )
+{% endmacro %}
+
+{% macro re_data_metric_correct_count(column_name, config) %}
+    {% set pattern = config.get('regexp') %}
+    {{ re_data_metric_regexp_count(column_name, pattern) }}
+{% endmacro %}
+
+{% macro re_data_metric_correct_percent(column_name, config) %}
+    {{ percentage_formula(re_data_metric_correct_count(column_name, config), re_data_metric_row_count()) }}
+{% endmacro %}
+
+{% macro re_data_metric_incorrect_count(column_name, config) %}
+    {% set pattern = config.get('regexp') %}
+    {{ re_data_metric_regexp_count(column_name, pattern) }}
+{% endmacro %}
+
+{% macro re_data_metric_incorrect_percent(column_name, config) %}
+    {{ percentage_formula(re_data_metric_incorrect_count(column_name, config), re_data_metric_row_count()) }}
 {% endmacro %}

--- a/macros/metrics/base/build_in/column_default.sql
+++ b/macros/metrics/base/build_in/column_default.sql
@@ -1,37 +1,37 @@
 
-{% macro re_data_metric_max(column_name) %}
+{% macro re_data_metric_max(column_name, config) %}
     max({{column_name}})
 {% endmacro %}
 
-{% macro re_data_metric_min(column_name) %}
+{% macro re_data_metric_min(column_name, config) %}
     min({{column_name}})
 {% endmacro %}
 
-{% macro re_data_metric_avg(column_name) %}
+{% macro re_data_metric_avg(column_name, config) %}
     avg(cast ({{column_name}} as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_stddev(column_name) %}
+{% macro re_data_metric_stddev(column_name, config) %}
     stddev(cast ( {{column_name}} as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_variance(column_name) %}
+{% macro re_data_metric_variance(column_name, config) %}
     variance(cast ( {{column_name}} as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_max_length(column_name) %}
+{% macro re_data_metric_max_length(column_name, config) %}
     max(length({{column_name}}))
 {% endmacro %}
 
-{% macro re_data_metric_min_length(column_name) %}
+{% macro re_data_metric_min_length(column_name, config) %}
     min(length({{column_name}}))
 {% endmacro %}
 
-{% macro re_data_metric_avg_length(column_name) %}
+{% macro re_data_metric_avg_length(column_name, config) %}
     avg(cast (length( {{column_name}} ) as {{ numeric_type() }}))
 {% endmacro %}
 
-{% macro re_data_metric_nulls_count(column_name) %}
+{% macro re_data_metric_nulls_count(column_name, config) %}
     coalesce(
         sum(
             case when {{column_name}} is null
@@ -42,7 +42,7 @@
     )
 {% endmacro %}
 
-{% macro re_data_metric_missing_count(column_name) %}
+{% macro re_data_metric_missing_count(column_name, config) %}
     coalesce(
         sum(
             case 

--- a/macros/metrics/base/build_in/table_default.sql
+++ b/macros/metrics/base/build_in/table_default.sql
@@ -1,9 +1,9 @@
 
-{% macro re_data_metric_row_count(time_filter) %}
+{% macro re_data_metric_row_count(time_filter, config) %}
     count(1)
 {% endmacro %}
 
-{% macro re_data_metric_freshness(time_filter) %}
+{% macro re_data_metric_freshness(time_filter, config) %}
     {{ freshness_expression(time_filter) }}
 {% endmacro %}
 
@@ -11,18 +11,18 @@
     {{ adapter.dispatch('freshness_expression', 're_data')(time_column) }}
 {% endmacro %}
 
-{% macro default__freshness_expression(time_column) %}
+{% macro default__freshness_expression(time_column, config) %}
    EXTRACT(EPOCH FROM ({{time_window_end()}} - max({{time_column}})))
 {% endmacro %}
 
-{% macro bigquery__freshness_expression(time_column) %}
+{% macro bigquery__freshness_expression(time_column, config) %}
     TIMESTAMP_DIFF ( timestamp({{ time_window_end()}}), timestamp(max({{time_column}})), SECOND)
 {% endmacro %}
 
-{% macro snowflake__freshness_expression(time_column) %}
+{% macro snowflake__freshness_expression(time_column, config) %}
    timediff(second, max({{time_column}}), {{- time_window_end() -}})
 {% endmacro %}
 
-{% macro redshift__freshness_expression(time_column) %}
+{% macro redshift__freshness_expression(time_column, config) %}
    DATEDIFF(second, max({{time_column}}), {{- time_window_end() -}})
 {% endmacro %}

--- a/macros/metrics/base/build_in/table_default.sql
+++ b/macros/metrics/base/build_in/table_default.sql
@@ -1,9 +1,9 @@
 
-{% macro re_data_metric_row_count(time_filter, config) %}
+{% macro re_data_metric_row_count(time_filter) %}
     count(1)
 {% endmacro %}
 
-{% macro re_data_metric_freshness(time_filter, config) %}
+{% macro re_data_metric_freshness(time_filter) %}
     {{ freshness_expression(time_filter) }}
 {% endmacro %}
 
@@ -11,18 +11,18 @@
     {{ adapter.dispatch('freshness_expression', 're_data')(time_column) }}
 {% endmacro %}
 
-{% macro default__freshness_expression(time_column, config) %}
+{% macro default__freshness_expression(time_column) %}
    EXTRACT(EPOCH FROM ({{time_window_end()}} - max({{time_column}})))
 {% endmacro %}
 
-{% macro bigquery__freshness_expression(time_column, config) %}
+{% macro bigquery__freshness_expression(time_column) %}
     TIMESTAMP_DIFF ( timestamp({{ time_window_end()}}), timestamp(max({{time_column}})), SECOND)
 {% endmacro %}
 
-{% macro snowflake__freshness_expression(time_column, config) %}
+{% macro snowflake__freshness_expression(time_column) %}
    timediff(second, max({{time_column}}), {{- time_window_end() -}})
 {% endmacro %}
 
-{% macro redshift__freshness_expression(time_column, config) %}
+{% macro redshift__freshness_expression(time_column) %}
    DATEDIFF(second, max({{time_column}}), {{- time_window_end() -}})
 {% endmacro %}

--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -53,12 +53,12 @@
 
 {% macro metrics_base_expression_table(time_filter, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
-    {% set project_context = re_data.get_project_context(macro_name, metric) %}
+    {% set macro = re_data.get_metric_macro(macro_name, metric) %}
 
     {% if config is not none %}
-        {{ project_context[macro_name](time_filter, config) }}
+        {{ macro(time_filter, config) }}
     {%- else %}
-        {{ project_context[macro_name](time_filter) }}
+        {{ macro(time_filter) }}
     {% endif %}
 
 {% endmacro %}
@@ -66,12 +66,12 @@
 
 {%- macro metrics_base_expression_column(column_name, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
-    {% set project_context = re_data.get_project_context(macro_name, metric) %}
+    {% set macro = re_data.get_metric_macro(macro_name, metric) %}
 
     {% if config is not none %}
-        {{ project_context[macro_name](column_name, config) }}
+        {{ macro(column_name, config) }}
     {%- else %}
-        {{ project_context[macro_name](column_name) }}
+        {{ macro(column_name) }}
     {% endif %}
 
 {% endmacro %}
@@ -95,16 +95,16 @@
 
 {% endmacro %}
 
-{%- macro get_project_context(macro_name, metric) %}
+{%- macro get_metric_macro(macro_name, metric) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
 
     {% if context['re_data'].get(macro_name) %}
-        {% set project_context = context['re_data'] %}
+        {% set macro = context['re_data'][macro_name] %}
     {%- else %}
-        {% set project_context = context[project_name] %}
+        {% set macro = context[project_name][macro_name] %}
     {% endif %}
 
-    {{ return (project_context) }}
+    {{ return (macro) }}
 
 {% endmacro %}
 

--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -53,11 +53,12 @@
 
 {% macro metrics_base_expression_table(time_filter, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
+    {% set project_context = re_data.get_project_context(macro_name, metric) %}
 
-    {% if context['re_data'].get(macro_name) %}
-        {{ context['re_data'][macro_name](time_filter, config) }}
+    {% if config is not none %}
+        {{ project_context[macro_name](time_filter, config) }}
     {%- else %}
-        {{ context[project_name][macro_name](time_filter, config) }}
+        {{ project_context[macro_name](time_filter) }}
     {% endif %}
 
 {% endmacro %}
@@ -65,11 +66,12 @@
 
 {%- macro metrics_base_expression_column(column_name, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
+    {% set project_context = re_data.get_project_context(macro_name, metric) %}
 
-    {% if context['re_data'].get(macro_name) %}
-        {{ context['re_data'][macro_name](column_name, config) }}
+    {% if config is not none %}
+        {{ project_context[macro_name](column_name, config) }}
     {%- else %}
-        {{ context[project_name][macro_name](column_name, config) }}
+        {{ project_context[macro_name](column_name) }}
     {% endif %}
 
 {% endmacro %}
@@ -81,7 +83,7 @@
     {% if metric_value is mapping %}
         {% set metric = metric_value.keys() | first %}
         {% if metric_value[metric] is none %}
-            {{ exceptions.raise_compiler_error("Empty configuration passed for metric: " ~ metric ~ ". If the metric doesn't use a config, please use the column name alone.") }}
+            {{ exceptions.raise_compiler_error("Empty configuration passed for metric: " ~ metric ~ ". If the metric doesn't use a config, please use the column name as a string.") }}
         {% endif %}
 
         {% set config = metric_value[metric] %}
@@ -93,4 +95,16 @@
 
 {% endmacro %}
 
+{%- macro get_project_context(macro_name, metric) %}
+    {% set macro_name = 're_data_metric' + '_' + metric %}
+
+    {% if context['re_data'].get(macro_name) %}
+        {% set project_context = context['re_data'] %}
+    {%- else %}
+        {% set project_context = context[project_name] %}
+    {% endif %}
+
+    {{ return (project_context) }}
+
+{% endmacro %}
 

--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -24,8 +24,15 @@
     {% do metrics_to_compute.extend(var('re_data:metrics_base')['column'].get(data_kind, [])) %}
     {% do metrics_to_compute.extend(metrics.get('column', {}).get(column_name, [])) %}    
 
-    {% for metric in metrics_to_compute %}
-        {% set expression = re_data.metrics_base_expression_column(column_name, metric) %}
+    {% for metric_value in metrics_to_compute %}
+        {% set config = dict() %}
+        {% if metric_value is mapping %}
+            {% set metric = metric_value.keys() | first %}
+            {% set config = metric_value[metric] %}
+        {%- else %}
+            {% set metric = metric_value %}
+        {% endif %}
+        {% set expression = re_data.metrics_base_expression_column(column_name, metric, config) %}
         {% do col_expr.append({ 'expr': expression, 'col_name': column_name, 'metric': metric}) %}
     {% endfor %}
 
@@ -61,13 +68,13 @@
 {% endmacro %}
 
 
-{%- macro metrics_base_expression_column(column_name, metric) %}
+{%- macro metrics_base_expression_column(column_name, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
 
     {% if context['re_data'].get(macro_name) %}
-        {{ context['re_data'][macro_name](column_name) }}
+        {{ context['re_data'][macro_name](column_name, config) }}
     {%- else %}
-        {{ context[project_name][macro_name](column_name) }}
+        {{ context[project_name][macro_name](column_name, config) }}
     {% endif %}
 
 {% endmacro %}

--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -47,8 +47,14 @@
     {% do metrics_to_compute.extend(var('re_data:metrics_base')['table']) %}
     {% do metrics_to_compute.extend(metrics.get('table', [])) %}
 
-    {% for metric in metrics_to_compute %}
-        {% set expression = re_data.metrics_base_expression_table(time_filter, metric) %}
+    {% for metric_value in metrics_to_compute %}
+        {% if metric_value is mapping %}
+            {% set metric = metric_value.keys() | first %}
+            {% set config = metric_value[metric] %}
+        {%- else %}
+            {% set metric = metric_value %}
+        {% endif %}
+        {% set expression = re_data.metrics_base_expression_table(time_filter, metric, config) %}
         {% do table_expr.append({ 'expr': expression, 'col_name': '', 'metric': metric}) %}
     {% endfor %}
 
@@ -56,13 +62,13 @@
 
 {% endmacro %}
 
-{% macro metrics_base_expression_table(time_filter, metric) %}
+{% macro metrics_base_expression_table(time_filter, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
 
     {% if context['re_data'].get(macro_name) %}
-        {{ context['re_data'][macro_name](time_filter) }}
+        {{ context['re_data'][macro_name](time_filter, config) }}
     {%- else %}
-        {{ context[project_name][macro_name](time_filter) }}
+        {{ context[project_name][macro_name](time_filter, config) }}
     {% endif %}
 
 {% endmacro %}

--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -53,12 +53,12 @@
 
 {% macro metrics_base_expression_table(time_filter, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
-    {% set macro = re_data.get_metric_macro(macro_name, metric) %}
+    {% set metric_macro = re_data.get_metric_macro(macro_name, metric) %}
 
     {% if config is not none %}
-        {{ macro(time_filter, config) }}
+        {{ metric_macro(time_filter, config) }}
     {%- else %}
-        {{ macro(time_filter) }}
+        {{ metric_macro(time_filter) }}
     {% endif %}
 
 {% endmacro %}
@@ -66,12 +66,12 @@
 
 {%- macro metrics_base_expression_column(column_name, metric, config) %}
     {% set macro_name = 're_data_metric' + '_' + metric %}
-    {% set macro = re_data.get_metric_macro(macro_name, metric) %}
+    {% set metric_macro = re_data.get_metric_macro(macro_name, metric) %}
 
     {% if config is not none %}
-        {{ macro(column_name, config) }}
+        {{ metric_macro(column_name, config) }}
     {%- else %}
-        {{ macro(column_name) }}
+        {{ metric_macro(column_name) }}
     {% endif %}
 
 {% endmacro %}
@@ -99,12 +99,12 @@
     {% set macro_name = 're_data_metric' + '_' + metric %}
 
     {% if context['re_data'].get(macro_name) %}
-        {% set macro = context['re_data'][macro_name] %}
+        {% set metric_macro = context['re_data'][macro_name] %}
     {%- else %}
-        {% set macro = context[project_name][macro_name] %}
+        {% set metric_macro = context[project_name][macro_name] %}
     {% endif %}
 
-    {{ return (macro) }}
+    {{ return (metric_macro) }}
 
 {% endmacro %}
 

--- a/macros/utils/formulas.sql
+++ b/macros/utils/formulas.sql
@@ -1,0 +1,8 @@
+{% macro percentage_formula(summation, total) %}
+    ( 
+        cast({{ summation }} as {{ numeric_type() }})
+    ) / 
+    nullif(
+        cast( {{ total }} as {{ numeric_type() }} )
+    , 0) * 100.0
+{% endmacro %}

--- a/macros/utils/regular_expression.sql
+++ b/macros/utils/regular_expression.sql
@@ -1,0 +1,15 @@
+{% macro regexp_match_expression(column_name, pattern) %}
+    {{ adapter.dispatch('regexp_match_expression', 're_data')(column_name, pattern) }}
+{% endmacro %}
+
+{% macro default__regexp_match_expression(column_name, pattern) %}
+    {{column_name}} ~ '{{pattern}}'
+{% endmacro %}
+
+{% macro bigquery__regexp_match_expression(column_name, pattern) %}
+    regexp_contains({{column_name}}, '{{pattern}}')
+{% endmacro %}
+
+{% macro snowflake__regexp_match_expression(column_name, pattern) %}
+    regexp_like({{column_name | upper}}, '{{pattern}}')
+{% endmacro %}

--- a/macros/utils/regular_expression.sql
+++ b/macros/utils/regular_expression.sql
@@ -1,15 +1,15 @@
-{% macro regexp_match_expression(column_name, pattern) %}
-    {{ adapter.dispatch('regexp_match_expression', 're_data')(column_name, pattern) }}
+{% macro regex_match_expression(column_name, pattern) %}
+    {{ adapter.dispatch('regex_match_expression', 're_data')(column_name, pattern) }}
 {% endmacro %}
 
-{% macro default__regexp_match_expression(column_name, pattern) %}
+{% macro default__regex_match_expression(column_name, pattern) %}
     {{column_name}} ~ '{{pattern}}'
 {% endmacro %}
 
-{% macro bigquery__regexp_match_expression(column_name, pattern) %}
+{% macro bigquery__regex_match_expression(column_name, pattern) %}
     regexp_contains({{column_name}}, '{{pattern}}')
 {% endmacro %}
 
-{% macro snowflake__regexp_match_expression(column_name, pattern) %}
+{% macro snowflake__regex_match_expression(column_name, pattern) %}
     regexp_like({{column_name | upper}}, '{{pattern}}')
 {% endmacro %}


### PR DESCRIPTION
## What
This change brings the ability to write custom metrics and has custom configurations passed in as arguments to each metric.

## How
By adding key-value pairs to each metric defined in `re_data:monitored:`, we are able to pass the config as a dictionary into each metric defined. This brings about additional flexibility in passing values specific every metric defined.

Related issue: https://github.com/re-data/re-data/issues/113
