### PR TITLE
use not_match_regex in context of regex given

### DIFF
--- a/integration_tests/data/expected/expected_sample_data_z_score.csv
+++ b/integration_tests/data/expected/expected_sample_data_z_score.csv
@@ -75,5 +75,5 @@ table_name,column_name,metric,z_score_value,last_value,last_avg,last_stddev,time
 """postgres"".""dq_raw"".""sample_table""","event_type","regex_test",0,4,4,0,"2021-05-03 00:00:00",86400
 """postgres"".""dq_raw"".""sample_table""","event_type","match_regex",-0.707106781086547,0,0.5,0.707106781186548,"2021-05-03 00:00:00",86400
 """postgres"".""dq_raw"".""sample_table""","event_type","match_regex_percent",-0.707106781182548,0,12.5,17.6776695296637,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","not_match_regex",0.707106781086547,4,3.5,0.707106781186548,"2021-05-03 00:00:00",86400
-"""postgres"".""dq_raw"".""sample_table""","event_type","not_match_regex_percent",0.707106781182548,100,87.5,17.6776695296637,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","not_match_regex",-0.707106781086547,0,0.5,0.707106781186548,"2021-05-03 00:00:00",86400
+"""postgres"".""dq_raw"".""sample_table""","event_type","not_match_regex_percent",-0.707106781182548,0,12.5,17.6776695296637,"2021-05-03 00:00:00",86400

--- a/macros/metrics/base/build_in/column_default.sql
+++ b/macros/metrics/base/build_in/column_default.sql
@@ -86,7 +86,7 @@
 
 {% macro re_data_metric_not_match_regex(column_name, config) %}
     {% set pattern = config.get('regex') %}
-    {{ re_data_metric_regex_count(column_name, pattern) }}
+    {{ re_data_metric_row_count() }} - {{ re_data_metric_regex_count(column_name, pattern) }}
 {% endmacro %}
 
 {% macro re_data_metric_not_match_regex_percent(column_name, config) %}


### PR DESCRIPTION
## What
When defining configuration for `not_match_regex` metric, it is done in this way:
```
not_match_regex:
    regex: [A-Z]+
```

The previous implementation takes in `[A-Z]+` as the pattern that defines what values don't match in the column, so it counts the values that match the pattern while the proposed change will count the number of values that don't match the given regex `[A-Z]+`. My thinking is that most users know the pattern they are trying to match and will like to consider others as non-matching. 

## How
Subtract the row count from the total matching the given regex.
