### PR TITLE
[BUGFIX]: Make cols_over_time model reference the monitored table

### DIFF
--- a/models/metrics/types/schema/re_data_columns_over_time.sql
+++ b/models/metrics/types/schema/re_data_columns_over_time.sql
@@ -15,10 +15,9 @@ select
     cols.is_nullable,
     cast ({{dbt_utils.current_timestamp_in_utc()}} as {{ timestamp_type() }} ) as detected_time
 from
-    {{ ref('re_data_columns')}} cols, {{ ref('re_data_tables')}} tables
+    {{ ref('re_data_columns')}} cols, {{ ref('re_data_monitored')}} tables
 where
-    cols.table_name = tables.table_name and
-    tables.actively_monitored = true
+    cols.table_name = tables.table_name
 )
 
 select


### PR DESCRIPTION
## What

`re_data_columns_over_time` model has been referencing the `re_data_tables` table to determine the tables to track, which is not valid with the logic of configuring monitored tables through the vars dynamically. Therefore, the we needed to repoint the model to take the data based on both static and dynamic configuration (this data is generated in `re_data_monitored` model).

## How

1. Change the `re_data_columns_over_time` CTE named `columns` to make inner join with the `re_data_monitored` table to determine the columns based on the configuration through vars.
2. Change the select condition in the same CTE (by removing `actively_monitored = true`, cause this filter already applies in the `re_data_monitored` final table.