### PR TITLE
use source and target as column names for normalizing

### DIFF
--- a/integration_tests/data/public_macros/normalizing/us_states_normalization.csv
+++ b/integration_tests/data/public_macros/normalizing/us_states_normalization.csv
@@ -1,4 +1,4 @@
-incorrect,correct
+source,target
 Ala.,Alabama
 Alaska,Alaska
 Ariz.,Arizona

--- a/integration_tests/models/public_macros/normalizing/us_states_normalized.sql
+++ b/integration_tests/models/public_macros/normalizing/us_states_normalized.sql
@@ -1,5 +1,5 @@
 with us_states_normalization_cte as (
-    select incorrect, correct from {{ ref('us_states_normalization') }}
+    select source, target from {{ ref('us_states_normalization') }}
 )
 
 {% set us_states_mapping = {'Ala.': 'Alabama', 'Alaska': 'Alaska', 'Ariz.': 'Arizona', 'Ark.': 'Arkansas', 'Calif.': 'California', 'Colo.': 'Colorado', 'Conn.': 'Connecticut',
@@ -16,8 +16,8 @@ with us_states_normalization_cte as (
     We have three ways of passing the source used for normalization
         1. passing a dbt model using ref('') which is of type Relation.
         2. passing a common table expression that contains the source mapping
-            Note: model or cte must include "incorrect" and "correct" column names used for normalization in 1. & 2. repectively
-        3. passing a dictionary of values that map from incorrect -> correct ie {[incorrect]: [correct]}
+            Note: model or cte must include "source" and "target" column names used for normalization in 1. & 2. repectively
+        3. passing a dictionary of values that map from source -> target ie {[source]: [target]}
  #}
 
 select distinct * from (

--- a/macros/public/normalizing/normalize_values.sql
+++ b/macros/public/normalizing/normalize_values.sql
@@ -8,7 +8,7 @@
             select * from {{ reference_table }}
         {% elif reference_table is mapping %}
             {% for key, value in reference_table.items() %}
-                select '{{key}}' as incorrect, '{{value}}' as correct
+                select '{{key}}' as source, '{{value}}' as target
                 {% if not loop.last %}union all{% endif %}
             {% endfor %}
         {% endif %}
@@ -20,13 +20,13 @@
         {{ re_data.normalize_expression_cte(reference_table) }}
         
         select s.*, 
-        case when t.incorrect is null
+        case when t.source is null
                 then s.{{column_name}}
-            else t.correct
+            else t.target
             end as {{ column_name + '__normalized'}} 
         from {{ source_relation }} s
         left join target_table t 
-        on t.incorrect = s.{{column_name}}
+        on t.source = s.{{column_name}}
     )
 {%- endmacro -%}
 


### PR DESCRIPTION
## What
Previously, we use incorrect and correct as column names expected for the `normalize_values` macro. I feel renaming to source and target is more semantically correct.