### PR TITLE
Feature macro filter_get_duplicates

### DIFF
--- a/integration_tests/data/expected/expected_duplicates.csv
+++ b/integration_tests/data/expected/expected_duplicates.csv
@@ -1,0 +1,18 @@
+transaction_id,creation_time,status,value,use_case
+1,2021-05-01 12:31:32,pending,100,take_first
+2,2021-05-01 12:35:35,pending,200,take_first
+3,2021-05-01 12:40:35,pending,300,take_first
+4,2021-05-02 12:35:35,completed,10,take_first
+5,2021-05-02 12:40:35,pending,100,take_first
+1,2021-05-01 12:40:35,completed,100,take_last
+2,2021-05-01 12:35:35,pending,200,take_last
+3,2021-05-02 12:31:32,completed,300,take_last
+4,2021-05-02 12:40:35,completed,40,take_last
+5,2021-05-02 12:40:35,pending,100,take_last
+1,2021-05-01 12:40:35,completed,100,take_all_statuses
+1,2021-05-01 12:31:32,pending,100,take_all_statuses
+2,2021-05-01 12:35:35,pending,200,take_all_statuses
+3,2021-05-02 12:31:32,completed,300,take_all_statuses
+3,2021-05-01 12:40:35,pending,300,take_all_statuses
+4,2021-05-02 12:40:35,completed,40,take_all_statuses
+5,2021-05-02 12:40:35,pending,100,take_all_statuses

--- a/integration_tests/data/expected/expected_duplicates.csv
+++ b/integration_tests/data/expected/expected_duplicates.csv
@@ -1,18 +1,7 @@
-transaction_id,creation_time,status,value,use_case
-1,2021-05-01 12:31:32,pending,100,take_first
-2,2021-05-01 12:35:35,pending,200,take_first
-3,2021-05-01 12:40:35,pending,300,take_first
-4,2021-05-02 12:35:35,completed,10,take_first
-5,2021-05-02 12:40:35,pending,100,take_first
-1,2021-05-01 12:40:35,completed,100,take_last
-2,2021-05-01 12:35:35,pending,200,take_last
-3,2021-05-02 12:31:32,completed,300,take_last
-4,2021-05-02 12:40:35,completed,40,take_last
-5,2021-05-02 12:40:35,pending,100,take_last
-1,2021-05-01 12:40:35,completed,100,take_all_statuses
-1,2021-05-01 12:31:32,pending,100,take_all_statuses
-2,2021-05-01 12:35:35,pending,200,take_all_statuses
-3,2021-05-02 12:31:32,completed,300,take_all_statuses
-3,2021-05-01 12:40:35,pending,300,take_all_statuses
-4,2021-05-02 12:40:35,completed,40,take_all_statuses
-5,2021-05-02 12:40:35,pending,100,take_all_statuses
+"transaction_id","creation_time","status","value","re_data_duplicates_group_rows_count","re_data_duplicates_group_row_number"
+1,"2021-05-01 12:31:32","pending",100,2,1
+1,"2021-05-01 12:40:35","completed",100,2,2
+3,"2021-05-01 12:40:35","pending",300,2,1
+3,"2021-05-02 12:31:32","completed",300,2,2
+4,"2021-05-02 12:35:35","completed",10,2,1
+4,"2021-05-02 12:40:35","completed",40,2,2

--- a/integration_tests/models/public_macros/filtering/duplicates.sql
+++ b/integration_tests/models/public_macros/filtering/duplicates.sql
@@ -1,0 +1,16 @@
+with x as 
+    {{ re_data.filter_remove_duplicates(
+        ref('duplicated'), ['transaction_id'], ['creation_time']) }}
+
+select *, 'take_first' as use_case from x
+
+union all
+
+select *, 'take_last' as use_case from {{ re_data.filter_remove_duplicates(
+        ref('duplicated'), ['transaction_id'], ['creation_time desc']) }} duplicates
+
+
+union all
+
+select *, 'take_all_statuses' as use_case from {{ re_data.filter_remove_duplicates(
+    ref('duplicated'), ['transaction_id', 'status'], ['creation_time desc']) }} duplicates

--- a/integration_tests/models/public_macros/filtering/duplicates.sql
+++ b/integration_tests/models/public_macros/filtering/duplicates.sql
@@ -1,16 +1,3 @@
-with x as 
-    {{ re_data.filter_remove_duplicates(
+ {{ re_data.filter_get_duplicates(
         ref('duplicated'), ['transaction_id'], ['creation_time']) }}
 
-select *, 'take_first' as use_case from x
-
-union all
-
-select *, 'take_last' as use_case from {{ re_data.filter_remove_duplicates(
-        ref('duplicated'), ['transaction_id'], ['creation_time desc']) }} duplicates
-
-
-union all
-
-select *, 'take_all_statuses' as use_case from {{ re_data.filter_remove_duplicates(
-    ref('duplicated'), ['transaction_id', 'status'], ['creation_time desc']) }} duplicates

--- a/integration_tests/models/public_macros/filtering/schema.yml
+++ b/integration_tests/models/public_macros/filtering/schema.yml
@@ -5,3 +5,7 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('expected_deduplicated')
+  - name: duplicates
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_duplicates')

--- a/integration_tests/python_tests/test_filters.py
+++ b/integration_tests/python_tests/test_filters.py
@@ -10,4 +10,13 @@ def test_deduplication(db, debug=True):
     dbt_run('--select deduplicated', db)
     dbt_test('--select deduplicated', db)
 
+
+def test_get_duplicates(db, debug=True):
+
+    print (f"Running setup and tests for {db}")
+
+    dbt_seed('--select duplicates expected_duplicates', db)
+    dbt_run('--select deduplicated', db)
+    dbt_test('--select deduplicated', db)
+
     print (f"Running tests completed for {db}")

--- a/integration_tests/python_tests/test_filters.py
+++ b/integration_tests/python_tests/test_filters.py
@@ -10,13 +10,12 @@ def test_deduplication(db, debug=True):
     dbt_run('--select deduplicated', db)
     dbt_test('--select deduplicated', db)
 
-
 def test_get_duplicates(db, debug=True):
 
     print (f"Running setup and tests for {db}")
 
     dbt_seed('--select duplicates expected_duplicates', db)
-    dbt_run('--select deduplicated', db)
-    dbt_test('--select deduplicated', db)
+    dbt_run('--select duplicates', db)
+    dbt_test('--select duplicates', db)
 
     print (f"Running tests completed for {db}")

--- a/macros/public/filtering/get_duplicates.sql
+++ b/macros/public/filtering/get_duplicates.sql
@@ -1,40 +1,31 @@
 {% https://github.com/re-data/re-data/issues/143 %}
 
-{%
+{#
 macro returns rows with she same key set (unique_cols)
 
 along with the fields of the base model duplicates information added:
 re_data_duplicates_count - total number of duplicates with the same current key set
 re_data_duplicate_row_number - number of a duplicate row inside the group of duplicates with the same current key set
-%}
-
-
-
-
-{% to be moved to re_data_utils? %}
-{% macro comma_delimited_list(args) %}
-    {%- for arg in args %} 
-        {{- arg -}} {{- ", " if not loop.last else "" -}}
-    {% endfor %}
-{% endmacro %}}
-
+#}
 
 {% macro filter_get_duplicates(relation, unique_cols, sort_columns) %}
     (
         with with_row_num_count as (
-            select *, row_number() over (
-                partition by {{ re_data.comma_delimited_list(unique_cols) }} {% if sort_columns %} order by {{ re_data.comma_delimited_list(sort_columns) }} {% endif %}
-            ) as re_data_duplicate_row_number
+            select *
             , count(*) over (
+            partition by {{ re_data.comma_delimited_list(unique_cols) }} 
+            ) as re_data_duplicates_group_rows_count
+            , row_number() over (
                 partition by {{ re_data.comma_delimited_list(unique_cols) }} {% if sort_columns %} order by {{ re_data.comma_delimited_list(sort_columns) }} {% endif %}
-            ) as re_data_duplicates_count
+            ) as re_data_duplicates_group_row_number
+
            
             from {{ relation }}
         ),
         duplicate_rows as (
-            select * from with_row_num_count where re_data_duplicates_count > 1
+            select * from with_row_num_count where re_data_duplicates_group_rows_count > 1
         )
-        {% return surrogate key as well? %}
+        {# return surrogate key as well? #}
         select *
         from duplicate_rows
     ) 

--- a/macros/public/filtering/get_duplicates.sql
+++ b/macros/public/filtering/get_duplicates.sql
@@ -1,0 +1,41 @@
+{% https://github.com/re-data/re-data/issues/143 %}
+
+{%
+macro returns rows with she same key set (unique_cols)
+
+along with the fields of the base model duplicates information added:
+re_data_duplicates_count - total number of duplicates with the same current key set
+re_data_duplicate_row_number - number of a duplicate row inside the group of duplicates with the same current key set
+%}
+
+
+
+
+{% to be moved to re_data_utils? %}
+{% macro comma_delimited_list(args) %}
+    {%- for arg in args %} 
+        {{- arg -}} {{- ", " if not loop.last else "" -}}
+    {% endfor %}
+{% endmacro %}}
+
+
+{% macro filter_get_duplicates(relation, unique_cols, sort_columns) %}
+    (
+        with with_row_num_count as (
+            select *, row_number() over (
+                partition by {{ re_data.comma_delimited_list(unique_cols) }} {% if sort_columns %} order by {{ re_data.comma_delimited_list(sort_columns) }} {% endif %}
+            ) as re_data_duplicate_row_number
+            , count(*) over (
+                partition by {{ re_data.comma_delimited_list(unique_cols) }} {% if sort_columns %} order by {{ re_data.comma_delimited_list(sort_columns) }} {% endif %}
+            ) as re_data_duplicates_count
+           
+            from {{ relation }}
+        ),
+        duplicate_rows as (
+            select * from with_row_num_count where re_data_duplicates_count > 1
+        )
+        {% return surrogate key as well? %}
+        select *
+        from duplicate_rows
+    ) 
+{% endmacro %}

--- a/macros/public/filtering/remove_duplicates.sql
+++ b/macros/public/filtering/remove_duplicates.sql
@@ -1,20 +1,13 @@
 
-{% macro comma_delimited_list(args) %}
-    {%- for arg in args %} 
-        {{- arg -}} {{- ", " if not loop.last else "" -}}
-    {% endfor %}
-{% endmacro %}}
+
 
 {% macro filter_remove_duplicates(relation, unique_cols, sort_columns) %}
     (
         with with_row_num as (
-            select *, row_number() over (
-                partition by {{ re_data.comma_delimited_list(unique_cols) }} {% if sort_columns %} order by {{ re_data.comma_delimited_list(sort_columns) }} {% endif %}
-            ) as re_data_row_num
-            from {{ relation }}
+            {{re_data.add_duplication_context(relation, unique_cols, sort_columns)}}
         ),
         one_row_num as (
-            select * from with_row_num where re_data_row_num = 1
+            select * from with_row_num where re_data_duplicates_group_row_number = 1
         )
         select {{ dbt_utils.star(from=relation) }}
         from one_row_num

--- a/macros/utils/comma_delimited_list.sql
+++ b/macros/utils/comma_delimited_list.sql
@@ -1,0 +1,5 @@
+{% macro comma_delimited_list(args) %}
+    {%- for arg in args %} 
+        {{- arg -}} {{- ", " if not loop.last else "" -}}
+    {% endfor %}
+{% endmacro %}}

--- a/macros/utils/deduplication/add_duplication_context.sql
+++ b/macros/utils/deduplication/add_duplication_context.sql
@@ -1,0 +1,13 @@
+{% macro add_duplication_context(relation, unique_cols, sort_columns) %}
+
+            select {{ dbt_utils.star(from=relation) }}
+            , count(*) over (
+                 partition by {{ re_data.comma_delimited_list(unique_cols) }} 
+            ) as re_data_duplicates_group_rows_count
+            , row_number() over (
+                partition by {{ re_data.comma_delimited_list(unique_cols) }} {% if sort_columns %} order by {{ re_data.comma_delimited_list(sort_columns) }} {% endif %}
+            ) as re_data_duplicates_group_row_number
+
+            from {{ relation }}
+
+{% endmacro %}


### PR DESCRIPTION
## What
new macro filter_get_duplicates

the issue is described in
https://github.com/re-data/re-data/issues/143

## How
new macro accepts the same arguments as 
[filter_remove_duplicates macro](https://re-data.github.io/re-data/latest/docs/reference/data_preparation/data_filtering#filter_remove_duplicates)
but returns all the rows which have been filtered away by filter_remove_duplicates.

macro adds 2 new duplication context columns to the table:
- re_data_duplicates_group_rows_count
number of duplicate rows with the same key columns values as for the current row
- re_data_duplicates_group_row_number
number of current row within the group of duplicate rows with the same key columns values as for the current row

