### PR TITLE
use raw strings for bigquery when quoting strings with escaped characters

### DIFF
--- a/macros/utils/json/quote.sql
+++ b/macros/utils/json/quote.sql
@@ -10,5 +10,5 @@
 
 {% macro bigquery__quote_text(text) %}
     {% set quoting = '"""' %}
-    {{quoting}}{{text}}{{quoting}}
+    r{{quoting}}{{text}}{{quoting}}
 {% endmacro %}


### PR DESCRIPTION
## What
When quoting large strings, escaped characters are not preserved. Using raw strings instead can help preserve such characters.
[Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical)