### PR TITLE
remove dbt_graph from generate_overview macro

### DIFF
--- a/macros/public/store/generate_overview.sql
+++ b/macros/public/store/generate_overview.sql
@@ -66,15 +66,7 @@
             {{ to_single_json(['data_type', 'is_nullable', 'is_datetime']) }} as {{ re_data.quote_column('data') }}
         from
             columns_casted
-    ) union all
-    (
-        select
-            'dbt_graph' as {{ re_data.quote_column('type') }},
-            null as {{ re_data.quote_column('table_name') }},
-            null as {{ re_data.quote_column('column_name') }},
-            {{- dbt_utils.current_timestamp_in_utc() -}} as {{ re_data.quote_column('computed_on') }},
-            {{ quote_text(dbt_graph)}} as {{ re_data.quote_column('data') }}
-    )order by {{ re_data.quote_column('computed_on')}} desc
+    ) order by {{ re_data.quote_column('computed_on')}} desc
     {% endset %}
 
     {% set overview_result = run_query(overview_query) %}


### PR DESCRIPTION
## What
As observed [here](https://re-data.slack.com/archives/C0295HAUJHG/p1640617444044100?thread_ts=1640616092.043700&cid=C0295HAUJHG) the dbt graph can be large enough to trigger the maximum standard SQL query length.

## How
We avoid having to add the dbt_graph to the select by using the `manifest.json` already generated by dbt on every run which contains the graph in a similar structure. 

This PR removes the dbt_graph from the generate_overview marcro.
