### PR TITLE
use ddl commands to drop schema for redshift

### DIFF
--- a/.github/workflows/run-db-tests.yml
+++ b/.github/workflows/run-db-tests.yml
@@ -44,6 +44,12 @@ jobs:
         run: 'echo $BIGQUERY_TESTING_SERVICE_ACCOUNT_BASE64 | base64 --decode > $BIGQUERY_TESTING_SERVICE_ACCOUNT_PATH'
         shell: bash
 
+      - name: Create Schema if needed
+        if: matrix.database == 'redshift'
+        working-directory: ./integration_tests
+        run: |
+          dbt run-operation create_required_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"
+
       - name: Install dependencies
         working-directory: ./integration_tests
         run: |

--- a/.github/workflows/run-db-tests.yml
+++ b/.github/workflows/run-db-tests.yml
@@ -52,7 +52,6 @@ jobs:
           dbt deps
 
       - name: Drop schemas
-        if: matrix.database == 'redshift'
         working-directory: ./integration_tests
         run: |
           dbt run-operation drop_all_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"

--- a/.github/workflows/run-db-tests.yml
+++ b/.github/workflows/run-db-tests.yml
@@ -44,19 +44,24 @@ jobs:
         run: 'echo $BIGQUERY_TESTING_SERVICE_ACCOUNT_BASE64 | base64 --decode > $BIGQUERY_TESTING_SERVICE_ACCOUNT_PATH'
         shell: bash
 
-      - name: Create Schema if needed
-        if: matrix.database == 'redshift'
-        working-directory: ./integration_tests
-        run: |
-          dbt run-operation create_required_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"
-
       - name: Install dependencies
         working-directory: ./integration_tests
         run: |
           pip install -r requirements.txt
           pip install dbt-${{ matrix.database }}==1.0.0
           dbt deps
+
+      - name: Drop schemas
+        if: matrix.database == 'redshift'
+        working-directory: ./integration_tests
+        run: |
           dbt run-operation drop_all_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"
+
+      - name: Create Schemas if needed
+        if: matrix.database == 'redshift'
+        working-directory: ./integration_tests
+        run: |
+          dbt run-operation create_required_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"
 
       - name: Test DB
         working-directory: ./integration_tests/python_tests

--- a/integration_tests/macros/drop_all_schemas.sql
+++ b/integration_tests/macros/drop_all_schemas.sql
@@ -29,3 +29,21 @@
     {% endset %}
     {% do run_query(drop_query) %}
 {% endmacro %}
+
+{% macro create_required_schemas(schema_name) %}
+    {% set schemas_to_drop = [
+        schema_name,
+        schema_name + '_re',
+        schema_name + '_re_internal',
+        schema_name + '_raw',
+        schema_name + '_expected',
+        schema_name + '_dbt_test__audit'
+    ] %}
+    {% set create_query %}
+        {% for schema in schemas_to_drop %}
+            create schema if not exists {{schema}};
+        {% endfor %}
+    {% endset %}
+    {{ log(create_query, info=True) }}
+    {% do run_query(create_query) %}
+{% endmacro %}

--- a/integration_tests/macros/drop_all_schemas.sql
+++ b/integration_tests/macros/drop_all_schemas.sql
@@ -1,5 +1,5 @@
-{% macro drop_all_schemas(schema_name) %}
-    {% set schemas_to_drop = [
+{% macro get_schemas_used(schema_name) %}
+    {% set schemas = [
         schema_name,
         schema_name + '_re',
         schema_name + '_re_internal',
@@ -7,6 +7,11 @@
         schema_name + '_expected',
         schema_name + '_dbt_test__audit'
     ] %}
+    {{ return (schemas) }}
+{% endmacro %}
+
+{% macro drop_all_schemas(schema_name) %}
+    {% set schemas_to_drop = get_schemas_used(schema_name) %}
     {{ adapter.dispatch('drop_all_schemas')(schemas_to_drop) }}
 {% endmacro %}
 
@@ -32,14 +37,7 @@
 
 {% macro create_required_schemas(schema_name) %}
     {# required to manually create schemas used for redshift tests #}
-    {% set schemas_to_drop = [
-        schema_name,
-        schema_name + '_re',
-        schema_name + '_re_internal',
-        schema_name + '_raw',
-        schema_name + '_expected',
-        schema_name + '_dbt_test__audit'
-    ] %}
+    {% set schemas_to_drop = get_schemas_used(schema_name) %}
     {% set create_query %}
         {% for schema in schemas_to_drop %}
             create schema if not exists {{schema}};

--- a/integration_tests/macros/drop_all_schemas.sql
+++ b/integration_tests/macros/drop_all_schemas.sql
@@ -7,8 +7,25 @@
         schema_name + '_expected',
         schema_name + '_dbt_test__audit'
     ] %}
+    {{ adapter.dispatch('drop_all_schemas')(schemas_to_drop) }}
+{% endmacro %}
+
+{% macro default__drop_all_schemas(schemas_to_drop) %}
     {% for schema in schemas_to_drop %}
         {% set relation = api.Relation.create(database=target.database, schema=schema) %}
         {% do adapter.drop_schema(relation) %}
     {% endfor %}
+{% endmacro %}
+
+{% macro redshift__drop_all_schemas(schemas_to_drop) %}
+    {# 
+        dropping schemas with adapter.drop_schema doesn't seem to work with redshift
+        so we default to issuing DDL commands to redshift
+    #}
+    {% set drop_query %}
+        {% for schema in schemas_to_drop %}
+            drop schema if exists {{schema}} cascade;
+        {% endfor %}
+    {% endset %}
+    {% do run_query(drop_query) %}
 {% endmacro %}

--- a/integration_tests/macros/drop_all_schemas.sql
+++ b/integration_tests/macros/drop_all_schemas.sql
@@ -31,6 +31,7 @@
 {% endmacro %}
 
 {% macro create_required_schemas(schema_name) %}
+    {# required to manually create schemas used for redshift tests #}
     {% set schemas_to_drop = [
         schema_name,
         schema_name + '_re',

--- a/integration_tests/macros/drop_all_schemas.sql
+++ b/integration_tests/macros/drop_all_schemas.sql
@@ -44,6 +44,5 @@
             create schema if not exists {{schema}};
         {% endfor %}
     {% endset %}
-    {{ log(create_query, info=True) }}
     {% do run_query(create_query) %}
 {% endmacro %}


### PR DESCRIPTION
Dropping schemas with [adapter.drop_schema](https://docs.getdbt.com/reference/dbt-jinja-functions/adapter#drop_schema) doesn't seem to work with redshift. Pending when we can identify and resolve the cause, we fall back to using DDL statements to drop schemas in redshift.