### PR TITLE
replace non alphanumeric chars with underscore

### DIFF
--- a/.github/workflows/run-db-tests.yml
+++ b/.github/workflows/run-db-tests.yml
@@ -32,8 +32,9 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Set the DQ_SCHEMA environment variable
+        shell: bash
         run: |
-          echo "DQ_SCHEMA=dq_${GITHUB_REF_SLUG//-/_}" >> $GITHUB_ENV
+          echo "DQ_SCHEMA=dq_${GITHUB_REF_SLUG//[^[:alnum:]]/_}" >> $GITHUB_ENV
 
       - name: Print DQ_SCHEMA
         run: |
@@ -121,8 +122,9 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Set the DQ_SCHEMA environment variable
+        shell: bash
         run: |
-          echo "DQ_SCHEMA=dq_${GITHUB_EVENT_REF_SLUG//-/_}" >> $GITHUB_ENV
+          echo "DQ_SCHEMA=dq_${GITHUB_EVENT_REF_SLUG//[^[:alnum:]]/_}" >> $GITHUB_ENV
 
       - name: Print DQ_SCHEMA
         run: |


### PR DESCRIPTION
## What
When a release is created, the event ref is contains a tag number e.g. `0.6.0`. We currently only replace `-` with `_`. Generating a schema name like `dq_0.6.0` is invalid. Ideally we should have something like `dq_0_6_0`

## How
This change replaces all non alphanumeric characters with `_` ensuring the dynamically generated schema name is always vaild.
