### PR TITLE
Support `identifier` used in sources

### DIFF
--- a/macros/meta/get_monitored.sql
+++ b/macros/meta/get_monitored.sql
@@ -9,7 +9,7 @@
             {% if el.config.get('re_data_monitored') %}
             
                 {% do monitored.append({
-                    'name': re_data.name_in_db(el.name),
+                    'name': re_data.name_in_db(el.identifier or el.name),
                     'schema': re_data.name_in_db(el.schema),
                     'database': re_data.name_in_db(el.database),
                     'time_filter': el.config.get('re_data_time_filter', none),


### PR DESCRIPTION
Sources can and quite often look like this:

```yaml
sources:
- name: my_source
  schema: my_schema
  tables:
    - name: site
      identifier: io_site  # <-- This is what is being fixed to be supported
      description: Table containing all site records from the IO stored in a jsonb column derived from ...
      columns:
        - name: record_id
          description: UUID generated on each insertion of a stream record
          tests:
            - not_null
            - unique
        - name: record_number
          description: Record number during stream processing
        - name: data
          ...
```

This microscopic change adds support for the semantic. Tested in my own very large project.

## What
Adds support for identifier in source configs

## How
Using a simple short circuit eval which prefers identifier which is always the actual database table name if utilized
