### PR TITLE
update dbt-core version used in testing

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Install dependencies and run
         run: |
-          pip install dbt-core==1.0.0
-          pip install dbt-postgres==1.0.0
+          pip install dbt-core==1.0.2
+          pip install dbt-postgres==1.0.2
           dbt deps
           dbt run
 

--- a/.github/workflows/run-db-tests.yml
+++ b/.github/workflows/run-db-tests.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ./integration_tests
         run: |
           pip install -r requirements.txt
-          pip install dbt-${{ matrix.database }}==1.0.0
+          pip install dbt-${{ matrix.database }}==1.0.2
           dbt deps
 
       - name: Drop schemas
@@ -139,6 +139,6 @@ jobs:
         working-directory: ./integration_tests
         run: |
           pip install -r requirements.txt
-          pip install dbt-${{ matrix.database }}==1.0.0
+          pip install dbt-${{ matrix.database }}==1.0.2
           dbt deps
           dbt run-operation drop_all_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"

--- a/.github/workflows/run-db-tests.yml
+++ b/.github/workflows/run-db-tests.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ./integration_tests
         run: |
           pip install -r requirements.txt
-          pip install dbt-${{ matrix.database }}==1.0.2
+          pip install dbt-${{ matrix.database }}==1.0.0
           dbt deps
 
       - name: Drop schemas
@@ -139,6 +139,6 @@ jobs:
         working-directory: ./integration_tests
         run: |
           pip install -r requirements.txt
-          pip install dbt-${{ matrix.database }}==1.0.2
+          pip install dbt-${{ matrix.database }}==1.0.0
           dbt deps
           dbt run-operation drop_all_schemas --args "{ schema_name: ${{ env.DQ_SCHEMA }} }" --profile re_data_${{ matrix.database }} --vars "{ source_schema: ${{ env.DQ_SCHEMA }} }"

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.2.5
 pyyaml==6.0
-dbt-core==1.0.0
+dbt-core>=1.0.0,<1.1.0
 dbt-postgres==1.0.0

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.2.5
 pyyaml==6.0
 dbt-core==1.0.2
-dbt-postgres==1.0.0
+dbt-postgres==1.0.2

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.2.5
 pyyaml==6.0
-dbt-core>=1.0.0,<1.1.0
+dbt-core==1.0.2
 dbt-postgres==1.0.0


### PR DESCRIPTION
## What
https://github.com/pallets/markupsafe/issues/284 introduced a change that breaks installation process in our integration tests.

## How
dbt has fixed this in `dbt-core` so we ensure that the integration tests use the latest version.
