### PR TITLE
handle schema change for re_data_z_score model

### DIFF
--- a/models/anomalies/re_data_schema_changes.sql
+++ b/models/anomalies/re_data_schema_changes.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        unique_key = 'id'
+        unique_key = 'id',
+        on_schema_change='sync_all_columns',
     )
 }}
 

--- a/models/anomalies/re_data_z_score.sql
+++ b/models/anomalies/re_data_z_score.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        unique_key = 'id'
+        unique_key = 'id',
+        on_schema_change='sync_all_columns',
     )
 }}
 

--- a/models/logs/re_data_test_history.sql
+++ b/models/logs/re_data_test_history.sql
@@ -1,6 +1,7 @@
 {{
     config(
         materialized='incremental',
+        on_schema_change='sync_all_columns',
     )
 }}
 

--- a/models/metrics/types/base/re_data_base_metrics.sql
+++ b/models/metrics/types/base/re_data_base_metrics.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        unique_key = 'id'
+        unique_key = 'id',
+        on_schema_change='sync_all_columns',
     )
 }}
 

--- a/models/metrics/types/schema/re_data_columns_over_time.sql
+++ b/models/metrics/types/schema/re_data_columns_over_time.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        unique_key = 'id'
+        unique_key = 'id',
+        on_schema_change='sync_all_columns',
     )
 }}
 

--- a/packages.yml
+++ b/packages.yml
@@ -4,4 +4,4 @@ packages:
     version: [">=0.7.0", "<0.9.0"]
 
   - package: fivetran/fivetran_utils
-    version: 0.3.3
+    version: 0.3.4


### PR DESCRIPTION
## What
We added some columns to the `re_data_z_score.sql` model and would like to handle running on past schemas that don't contain new columns. By default dbt will ignore the new columns but that's not what should happen in our case.

[Reference](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/configuring-incremental-models#what-if-the-columns-of-my-incremental-model-change)
