### PR TITLE
double quote column names for redshift queries

### DIFF
--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -63,6 +63,9 @@
 {%- macro metrics_base_expression_column(column_name, metric_name, config, table_name, time_filter) %}
     {% set metric_macro = re_data.get_metric_macro(metric_name) %}
     {% set context = {'time_filter': time_filter, 'metric_name': metric_name, 'config': config, 'table_name': table_name, 'column_name': column_name} %}
+    {% if target.type == 'redshift' %} 
+        {% do context.update({'column_name': '\"' + column_name + '\"'}) %}
+    {% endif %}
 
     {{ metric_macro(context) }}
 


### PR DESCRIPTION
## What
A database error is thrown when re_data selects columns that are reserved names in redshift. To avoid this, we can quote the column names in the queries generated by re_data.

[Noticed here](https://re-data.slack.com/archives/C01FNUHNK7D/p1647283517983969)
