### PR TITLE
fix bug in schema changes

### DIFF
--- a/models/anomalies/re_data_schema_changes.sql
+++ b/models/anomalies/re_data_schema_changes.sql
@@ -8,6 +8,7 @@
 
 -- depends_on: {{ ref('re_data_run_started_at') }}
 -- depends_on: {{ ref('re_data_columns_over_time') }}
+-- depends_on: {{ ref('re_data_monitored') }}
 
 {% if execute and not re_data.in_compile() %}
     {% set last_data_points %} 
@@ -36,15 +37,21 @@
     {{ dummy_empty_schema_changes_table() }}
 {% else %}
 
-    with curr_schema as (
+    with curr_monitored_schema as (
         select * from {{ ref('re_data_columns_over_time')}}
         where detected_time = '{{ most_recent_time }}'
+        and table_name in (
+            select {{ full_table_name('name', 'schema', 'database') }} from {{ ref('re_data_monitored')}}
+        )
     ),
 
 
-    prev_schema as (
+    prev_monitored_schema as (
         select * from {{ ref('re_data_columns_over_time')}}
         where detected_time = '{{ prev_most_recent}}'
+        and table_name in (
+            select {{ full_table_name('name', 'schema', 'database') }} from {{ ref('re_data_monitored')}}
+        )
     ),
 
     all_changes as (
@@ -60,7 +67,7 @@
                 prev.data_type as prev_data_type,
                 prev.is_nullable as prev_is_nullable
             
-            from curr_schema curr inner join prev_schema prev on (curr.table_name = prev.table_name and curr.column_name = prev.column_name)
+            from curr_monitored_schema curr inner join prev_monitored_schema prev on (curr.table_name = prev.table_name and curr.column_name = prev.column_name)
             where
                 curr.data_type != prev.data_type or 
                 curr.is_nullable != prev.is_nullable
@@ -81,8 +88,13 @@
                 null as prev_data_type,
                 null as prev_is_nullable
             
-            from curr_schema curr left join prev_schema prev on (curr.table_name = prev.table_name and curr.column_name = prev.column_name)
+            from curr_monitored_schema curr left join prev_monitored_schema prev on (curr.table_name = prev.table_name and curr.column_name = prev.column_name)
             where prev.table_name is null and prev.column_name is null
+            {# note: when a column is added, make sure we only detect for models that were previously monitored,
+            this avoids a situation where a newly monitored model has all its columns detected with 'column_added' operation#}
+            and curr.table_name in (
+                select table_name from prev_monitored_schema
+            )
         
         )
 
@@ -101,7 +113,7 @@
                 prev.data_type as prev_data_type,
                 prev.is_nullable as prev_is_nullable
             
-            from prev_schema prev left join curr_schema curr on (curr.table_name = prev.table_name and curr.column_name = prev.column_name)
+            from prev_monitored_schema prev left join curr_monitored_schema curr on (curr.table_name = prev.table_name and curr.column_name = prev.column_name)
             where curr.table_name is null and curr.column_name is null
 
         )


### PR DESCRIPTION
## What
When a model has its config property `re_data_monitored` changed to true from false or vice versa, re_data currently detects columns in affected models as either all removed or added respectively. This is an unexpected behaviour as monitoring or un-monitoring a node doesn't constitute schema changes.

## How
Ensure that schema changes are only detected for currently monitored tables.

Note that in future releases, we may consider adding a message that shows a table just started being monitored and vice versa.
