### PR TITLE
configure slack alerting per model to specific users

### DIFF
--- a/macros/meta/get_monitored.sql
+++ b/macros/meta/get_monitored.sql
@@ -3,7 +3,7 @@
     {% set both = []%}
     {% do both.extend(graph.nodes.values()) %}
     {% do both.extend(graph.sources.values()) %}
-    {% set slack_config = re_data.get_slack_config() %}
+    {% set owners_config = re_data.get_owners_config() %}
 
     {% for el in both %}
         {% if el.resource_type in ['model', 'seed', 'source'] %}
@@ -17,7 +17,7 @@
                     'metrics': re_data.metrics_in_db(el.config.get('re_data_metrics', {})),
                     'columns': re_data.columns_in_db(el.config.get('re_data_columns', [])),
                     'anomaly_detector': el.config.get('re_data_anomaly_detector', var('re_data:anomaly_detector', {})),
-                    'slack_owners': re_data.prepare_slack_model_owners(el.config.get('re_data_slack_owners', []), slack_config),
+                    'owners': re_data.prepare_model_owners(el.config.get('re_data_owners', []), owners_config),
                     })
                 %}
             {% endif %}
@@ -55,7 +55,7 @@
         'metrics': re_data.metrics_in_db(metrics),
         'columns': re_data.columns_in_db(columns),
         'anomaly_detector': var('re_data:anomaly_detector', {}),
-        'slack_owners': {}
+        'owners': {}
         }]) 
     }}
 
@@ -97,37 +97,29 @@
     {% endif %}
 {% endmacro %}
 
-{% macro get_slack_config() %}
-    {% set slack_config = var('re_data:slack_config', {}) %}
-    {{ return (slack_config) }}
+{% macro get_owners_config() %}
+    {% set owners_config = var('re_data:owners_config', {}) %}
+    {{ return (owners_config) }}
 {% endmacro %}
 
-{% macro prepare_slack_model_owners(slack_owners, slack_config) %}
-    {# 
-        loop through slack_owners that have member set in re_data:slack_config.
-        if the owner is defined as a group in re_data:slack_config, then add the group members to the slack_owners list.
-        e.g.
-        user1: xxx
-        user2: yyy
-        user3: zzz
-        team: [user1, user2]
-
-        if team is passed in as a slack_owner, then the slack_owners list will contain user1, user2.
-        This is used to mention the owners in the slack message individually.
-     #}
+{% macro prepare_model_owners(re_data_owners, owners_config) %}
     {% set owners = {} %}
-    {% for owner in slack_owners if slack_config.get(owner) %}
-        {% set member = slack_config.get(owner) %}
-        {% if re_data.is_list(member) %}
-            {% for key in member %}
-                {% if key in slack_config %}
-                    {% do owners.update({key: slack_config[key] }) %}
-                {% endif %}
-            {% endfor %}
-        {% else %}
-            {% do owners.update({owner: member }) %}
-        {% endif %}
+    {% set seen_identifiers = {} %}
+    {% for owner in re_data_owners if owners_config.get(owner) %}
+        {% set members = owners_config.get(owner) %}
+        {% for member in members %}
+            {% set identifier = member.get('identifier') %}
+            {% if identifier not in seen_identifiers %}
+            {% do seen_identifiers.update({identifier: true }) %}
+            {% do owners.update({
+                identifier: {
+                    'notify_channel': member.get('type'),
+                    'owner': owner,
+                    'name': member.get('name') 
+                } 
+            }) %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-
     {{ return (owners) }}
 {% endmacro %}

--- a/macros/post_hook/re_data_monitored.sql
+++ b/macros/post_hook/re_data_monitored.sql
@@ -4,7 +4,7 @@
     {% do re_data.insert_list_to_table(
         this,
         monitored,
-        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector', 'slack_owners']
+        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector', 'owners']
     ) %}
 
     {% set monitored_set = {} %}
@@ -23,7 +23,7 @@
     {% do re_data.insert_list_to_table(
         this,
         not_yet_monitored,
-        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector', 'slack_owners']
+        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector', 'owners']
     ) %}
 
     {{ return('') }}

--- a/macros/post_hook/re_data_monitored.sql
+++ b/macros/post_hook/re_data_monitored.sql
@@ -4,7 +4,7 @@
     {% do re_data.insert_list_to_table(
         this,
         monitored,
-        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector']
+        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector', 'slack_owners']
     ) %}
 
     {% set monitored_set = {} %}
@@ -23,7 +23,7 @@
     {% do re_data.insert_list_to_table(
         this,
         not_yet_monitored,
-        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector']
+        ['name', 'schema', 'database', 'time_filter', 'metrics', 'columns', 'anomaly_detector', 'slack_owners']
     ) %}
 
     {{ return('') }}

--- a/macros/public/store/export_alerts.sql
+++ b/macros/public/store/export_alerts.sql
@@ -26,7 +26,7 @@
             metrics,
             columns,
             anomaly_detector,
-            slack_owners
+            owners
         from {{ ref('re_data_monitored') }}
     {% endset %}
     {% set query_result = run_query(monitored_query) %}

--- a/macros/public/store/export_alerts.sql
+++ b/macros/public/store/export_alerts.sql
@@ -1,4 +1,4 @@
-{% macro export_alerts(start_date, end_date, alerts_path=None) %}
+{% macro export_alerts(start_date, end_date, alerts_path=None, monitored_path=None) %}
     {% set alerts_query %}
         select
             type as {{ re_data.quote_column('type') }},
@@ -18,4 +18,18 @@
     {% set query_result = run_query(alerts_query) %}
     {% set alerts_file_path = alerts_path or 'target/re_data/alerts.json' %}
     {% do query_result.to_json(alerts_file_path) %}
+
+    {% set monitored_query %}
+        select
+            {{ full_table_name('name', 'schema', 'database') }} as {{ re_data.quote_column('model') }},
+            time_filter,
+            metrics,
+            columns,
+            anomaly_detector,
+            slack_owners
+        from {{ ref('re_data_monitored') }}
+    {% endset %}
+    {% set query_result = run_query(monitored_query) %}
+    {% set monitored_file_path = monitored_path or 'target/re_data/monitored.json' %}
+    {% do query_result.to_json(monitored_file_path) %}
 {% endmacro %}

--- a/macros/utils/is_list.sql
+++ b/macros/utils/is_list.sql
@@ -1,0 +1,7 @@
+{% macro is_list(obj) %}
+    {% if not obj %}
+        {{ return (False) }}
+    {% endif %}
+    {% set check = obj is iterable and (obj is not string and obj is not mapping) %}
+    {{ return (check) }}
+{% endmacro %}

--- a/macros/utils/mock/empty_tables.sql
+++ b/macros/utils/mock/empty_tables.sql
@@ -48,7 +48,8 @@
         cast (some_string as {{ string_type() }} ) as time_filter,
         cast (some_string as {{ string_type() }} ) as metrics,
         cast (some_string as {{ string_type() }} ) as columns,
-        cast (some_string as {{ string_type() }} ) as anomaly_detector
+        cast (some_string as {{ string_type() }} ) as anomaly_detector,
+        cast (some_string as {{ string_type() }} ) as slack_owners
     from dummy_table
     where some_num = 2
 {% endmacro %}

--- a/macros/utils/mock/empty_tables.sql
+++ b/macros/utils/mock/empty_tables.sql
@@ -49,7 +49,7 @@
         cast (some_string as {{ string_type() }} ) as metrics,
         cast (some_string as {{ string_type() }} ) as columns,
         cast (some_string as {{ string_type() }} ) as anomaly_detector,
-        cast (some_string as {{ string_type() }} ) as slack_owners
+        cast (some_string as {{ string_type() }} ) as owners
     from dummy_table
     where some_num = 2
 {% endmacro %}


### PR DESCRIPTION
## What
This feature allows the user to set slack owners for a particular model and also configuring the member id mapping so slack users can be mentioned using the notifications feature.

Usage:

Model
```sql
{{
    config(
        re_data_monitored=true,
        re_data_time_filter='time_created',
        re_data_anomaly_detector={'name': 'z_score', 'threshold': 2.2},
        re_data_slack_owners=['backend'], # this can either be set to a particular user or a team defined in `re_data:slack_config`
    )
}}
```

dbt_project.yml
```yaml
vars:
  re_data:anomaly_detector:
    name: modified_z_score
    threshold: 3
  re_data:slack_config:
    deji: U02FHBSTXXX
    mateusz: U01F80NJXXX
    emmanuel: U02RD3S3XXX
    backend: [deji, mateusz] # defining a team, this consists of keys within the same yaml dictionary
    frontend: [deji, emmanuel]
```

## How
When a slack notification is sent, the slack owner defined in the model is mentioned in the alert message.
