### PR TITLE
Fix problem with alias not properly handled

### DIFF
--- a/macros/meta/get_monitored.sql
+++ b/macros/meta/get_monitored.sql
@@ -8,9 +8,8 @@
     {% for el in both %}
         {% if el.resource_type in ['model', 'seed', 'source'] %}
             {% if el.config.get('re_data_monitored') %}
-            
                 {% do monitored.append({
-                    'name': re_data.name_in_db(el.identifier or el.name),
+                    'name': re_data.name_in_db(el.identifier or el.alias or el.name),
                     'schema': re_data.name_in_db(el.schema),
                     'database': re_data.name_in_db(el.database),
                     'time_filter': el.config.get('re_data_time_filter', none),


### PR DESCRIPTION
## What
When somebody is using an alias in the dbt model config, dbt creates a table with the alias name used.
We need to take this into account when computing metrics.