### PR TITLE
serialize tables exported to json 

### DIFF
--- a/macros/metrics/base/queries.sql
+++ b/macros/metrics/base/queries.sql
@@ -12,7 +12,9 @@
             {% set for_cols = fromjson(re_data.row_value(mtable, 'columns')) %}
             {% set for_cols_dict = re_data.dict_from_list(for_cols) %}
             {% set table_name = re_data.full_table_name_values(name, schema, database) %}
- 
+
+            -- (todo: dejii): possible optimization: query re_data_columns only once before the loop, and store results in an efficient way (e.g. in a dict) and look up using a key (name_schema_database)
+            -- currently, we query re_data_columns for each table
             {% set columns_query %}
                 select * from {{ ref('re_data_columns') }}
                 where name = '{{ name }}' and schema = '{{ schema }}' and database = '{{ database }}'

--- a/macros/public/store/export_table_samples.sql
+++ b/macros/public/store/export_table_samples.sql
@@ -1,0 +1,15 @@
+{% macro export_table_samples(start_date, end_date, table_samples_path=None) %}
+    {% set table_samples_query %}
+        select
+            table_name,
+            sample_data,
+            sampled_on
+        from
+            {{ ref('re_data_table_samples') }}
+    {% endset %}
+
+    {% set query_result = run_query(table_samples_query) %}
+    {% set table_samples_file_path = table_samples_path or 'target/re_data/table_samples.json' %}
+    {% do query_result.to_json(table_samples_file_path) %}
+
+{% endmacro %}

--- a/macros/public/store/export_tests_history.sql
+++ b/macros/public/store/export_tests_history.sql
@@ -6,7 +6,6 @@
             test_name,
             run_at,
             status,
-            run_at, 
             execution_time, 
             message, 
             failures_count, 

--- a/macros/public/store/export_tests_history.sql
+++ b/macros/public/store/export_tests_history.sql
@@ -6,7 +6,6 @@
             test_name,
             run_at,
             status,
-            test_name,
             run_at, 
             execution_time, 
             message, 

--- a/macros/public/store/export_tests_history.sql
+++ b/macros/public/store/export_tests_history.sql
@@ -1,0 +1,27 @@
+{% macro export_tests_history(start_date, end_date, tests_history_path=None) %}
+    {% set tests_history_query %}
+        select
+            table_name,
+            column_name,
+            test_name,
+            run_at,
+            status,
+            test_name,
+            run_at, 
+            execution_time, 
+            message, 
+            failures_count, 
+            failures_json, 
+            failures_table,
+            severity, 
+            compiled_sql
+        from
+            {{ ref('re_data_test_history') }}
+        where date(run_at) between '{{start_date}}' and '{{end_date}}' 
+    {% endset %}
+
+    {% set query_result = run_query(tests_history_query) %}
+    {% set tests_history_file_path = tests_history_path or 'target/re_data/tests_history.json' %}
+    {% do query_result.to_json(tests_history_file_path) %}
+
+{% endmacro %}

--- a/macros/public/store/generate_overview.sql
+++ b/macros/public/store/generate_overview.sql
@@ -81,16 +81,6 @@
                 when type = 'anomaly' then time_window_end between '{{ start_date }}' and '{{ end_date }}'
                 else time_window_end >= '{{ start_date }}'
             end
-    ) union all
-    (
-        select
-            {{ overview_select_base('test', 'run_at')}}
-            {{ to_single_json([
-                'status', 'test_name', 'run_at', 'execution_time', 'message', 'failures_count', 'failures_json', 'failures_table', 'severity', 'compiled_sql'
-            ]) }} as {{ re_data.quote_column('data') }}
-        from
-            {{ ref('re_data_test_history') }}
-        where date(run_at) between '{{start_date}}' and '{{end_date}}' 
     )
     order by {{ re_data.quote_column('computed_on')}} desc
     {% endset %}

--- a/macros/samples/internal_model_template.sql
+++ b/macros/samples/internal_model_template.sql
@@ -1,0 +1,50 @@
+{%- macro order_by_if_time_filter(time_filter) -%}
+    {%- if time_filter is not none -%}
+        order by {{ time_filter }} desc
+    {%- endif -%}
+{%- endmacro -%}
+
+
+{% macro re_data_last_table_samples() %}
+    {{ re_data.generate_depends(['re_data_monitored', 're_data_columns', 're_data_run_started_at', 're_data_last_table_samples_part']) }}
+
+    {{
+        config(
+            materialized='table',
+        )
+    }}
+
+    {% if not re_data.in_compile() %}
+        {%- set tables = run_query(re_data.get_tables()) %}
+
+        {% set samples_list = [] %}
+        {%- for sample_table in tables %}
+            {% set name = re_data.row_value(sample_table, 'name') %}
+            {% set schema = re_data.row_value(sample_table, 'schema') %}
+            {% set database = re_data.row_value(sample_table, 'database') %}
+            {% set time_filter = re_data.row_value(sample_table, 'time_filter') %}    
+            {% set table_name = re_data.full_table_name_values(name, schema, database) %}
+
+            {% set samples_query %}
+                select * from {{ table_name }}
+                {{ order_by_if_time_filter(time_filter) }}
+                limit 10
+            {% endset %}
+
+            {% set samples = re_data.agate_to_list(run_query(samples_query)) %}
+            {% do samples_list.append({
+                'table_name': table_name,
+                'sample_data': samples,
+            }) %}
+
+        {% endfor %}
+        {% do re_data.insert_list_to_table(
+                ref('re_data_last_table_samples_part'),
+                samples_list,
+                ['table_name', 'sample_data']
+            ) %}
+    {% endif %}
+
+    {{ re_data.empty_last_table_samples() }}
+
+{% endmacro %}

--- a/macros/samples/internal_model_template.sql
+++ b/macros/samples/internal_model_template.sql
@@ -14,7 +14,10 @@
         )
     }}
 
-    {% if not re_data.in_compile() %}
+    {% if var.has_var('re_data:store_table_samples') %}
+        {% set store_samples = var('re_data:store_table_samples') %}
+    {% endif %}
+    {% if not re_data.in_compile() and store_samples is sameas true %}
         {%- set tables = run_query(re_data.get_tables()) %}
 
         {% set samples_list = [] %}

--- a/macros/utils/agate/row_value.sql
+++ b/macros/utils/agate/row_value.sql
@@ -7,7 +7,14 @@
     {% set col_names = table.column_names %}
     {% set query_result = [] %}
     {% for row in table.rows %}
-        {% do query_result.append('' ~ row.dict()) %}
+        {% set pairs = [] %}
+        {% for col_name in col_names %}
+            {% set value = row.get(col_name) | string %}
+            {% do pairs.append('"' ~ col_name ~ '":' ~ '"' ~ (value | replace('"', '\\\"') ) ~ '"') %}
+        {% endfor %}
+        {% set joined_pairs = '{' ~ (pairs | join(',')) ~ '}' %}
+        {% do query_result.append(joined_pairs) %}
     {% endfor %}
+    {% set query_result = '[' ~ (query_result | join(',')) ~ ']' %}
     {{ return (query_result) }}
 {% endmacro %}

--- a/macros/utils/agate/row_value.sql
+++ b/macros/utils/agate/row_value.sql
@@ -10,7 +10,7 @@
         {% set pairs = [] %}
         {% for col_name in col_names %}
             {% set value = row.get(col_name) | string %}
-            {% do pairs.append('"' ~ col_name ~ '":' ~ '"' ~ (value | replace('"', '\\\"') ) ~ '"') %}
+            {% do pairs.append('"' ~ (col_name | lower) ~ '":' ~ '"' ~ (value | replace('"', '\\\"') ) ~ '"') %}
         {% endfor %}
         {% set joined_pairs = '{' ~ (pairs | join(',')) ~ '}' %}
         {% do query_result.append(joined_pairs) %}

--- a/macros/utils/mock/empty_tables.sql
+++ b/macros/utils/mock/empty_tables.sql
@@ -32,6 +32,15 @@
     }}
 {% endmacro %}
 
+{% macro empty_last_table_samples() %}
+    {{
+        re_data.empty_table_generic([
+            ('table_name', 'string'),
+            ('sample_data', 'string')
+        ])
+    }}
+{% endmacro %}
+
 {% macro empty_columns_table() %}
     {{
         re_data.empty_table_generic([

--- a/models/internal/samples/re_data_last_table_samples.sql
+++ b/models/internal/samples/re_data_last_table_samples.sql
@@ -1,0 +1,1 @@
+{{ re_data_last_table_samples() }}

--- a/models/internal/samples/re_data_last_table_samples_part.sql
+++ b/models/internal/samples/re_data_last_table_samples_part.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized='table',
+    )
+}}
+
+{{ re_data.empty_last_table_samples() }}

--- a/models/metrics/types/samples/re_data_table_samples.sql
+++ b/models/metrics/types/samples/re_data_table_samples.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized='incremental',
+        materialized='table',
         unique_key = 'table_name',
         on_schema_change='sync_all_columns',
     )

--- a/models/metrics/types/samples/re_data_table_samples.sql
+++ b/models/metrics/types/samples/re_data_table_samples.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key = 'table_name',
+        on_schema_change='sync_all_columns',
+    )
+}}
+
+-- depends_on: {{ ref('re_data_last_table_samples') }}
+-- depends_on: {{ ref('re_data_last_table_samples_part') }}
+
+select
+    table_name,
+    sample_data,
+    {{- dbt_utils.current_timestamp_in_utc() -}} as sampled_on
+
+from {{ ref('re_data_last_table_samples_part') }}


### PR DESCRIPTION
## What
- Constructs json from the results of `run_query()` using jinja2.
- Export tests history to a separate file
- Create model that stores sample rows for monitored tables
