### PR TITLE
[WIP] Add the new configuration `re_data_time_filter_data_type`

### DIFF
--- a/macros/meta/get_monitored.sql
+++ b/macros/meta/get_monitored.sql
@@ -33,6 +33,7 @@
                     'schema': re_data.name_in_db(el.schema),
                     'database': re_data.name_in_db(el.database),
                     'time_filter': el.config.get('re_data_time_filter', none),
+                    'time_filter_data_type': el.config.get('re_data_time_filter_data_type', none),
                     'metrics': re_data.metrics_in_db(el.config.get('re_data_metrics', {})),
                     'columns': re_data.columns_in_db(el.config.get('re_data_columns', [])),
                     'anomaly_detector': el.config.get('re_data_anomaly_detector', var('re_data:anomaly_detector', {})),

--- a/macros/metrics/base/expression.sql
+++ b/macros/metrics/base/expression.sql
@@ -1,21 +1,21 @@
-{% macro metrics_base_expressions(table_name, time_filter, metrics, columns, table_level=False) %}
+{% macro metrics_base_expressions(table_name, time_filter, time_filter_data_type, metrics, columns, table_level=False) %}
 
     {% set col_expr = [] %}
 
     {% for col in columns %}
         {% set column_name = re_data.row_value(col, 'column_name') %}
-        {% do col_expr.extend(re_data.metrics_base_expression_column_all(table_name, metrics, col, time_filter)) %}
+        {% do col_expr.extend(re_data.metrics_base_expression_column_all(table_name, metrics, col, time_filter, time_filter_data_type)) %}
     {% endfor %}
 
     {% if table_level %}
-        {% do col_expr.extend(re_data.metrics_base_expresion_table_all(table_name, time_filter, metrics)) %}
+        {% do col_expr.extend(re_data.metrics_base_expresion_table_all(table_name, time_filter, time_filter_data_type, metrics)) %}
     {% endif %}
 
     {{ return (col_expr) }}
 
 {% endmacro %}
 
-{% macro metrics_base_expression_column_all(table_name, metrics, column, time_filter) %}
+{% macro metrics_base_expression_column_all(table_name, metrics, column, time_filter, time_filter_data_type) %}
 
     {%- set col_expr = [] %}
     {%- set metrics_to_compute = [] %}
@@ -26,7 +26,7 @@
 
     {% for metric_value in metrics_to_compute %}
         {% set metric_obj = re_data.extract_metric_config(metric_value) %}
-        {% set expression = re_data.metrics_base_expression_column(column_name, metric_obj['metric'], metric_obj['config'], table_name, time_filter) %}
+        {% set expression = re_data.metrics_base_expression_column(column_name, metric_obj['metric'], metric_obj['config'], table_name, time_filter, time_filter_data_type) %}
         {% do col_expr.append({ 'expr': expression, 'col_name': column_name, 'metric': metric_obj['metric']}) %}
     {% endfor %}
 
@@ -35,7 +35,7 @@
 {% endmacro %}
 
 
-{% macro metrics_base_expresion_table_all(table_name, time_filter, metrics) %}
+{% macro metrics_base_expresion_table_all(table_name, time_filter, time_filter_data_type, metrics) %}
     {%- set table_expr = [] %}
     {%- set metrics_to_compute = [] %}
     {% do metrics_to_compute.extend(var('re_data:metrics_base').get('table', [])) %}
@@ -43,7 +43,7 @@
 
     {% for metric_value in metrics_to_compute %}
         {% set metric_obj = re_data.extract_metric_config(metric_value) %}
-        {% set expression = re_data.metrics_base_expression_table(time_filter, metric_obj['metric'], metric_obj['config'], table_name) %}
+        {% set expression = re_data.metrics_base_expression_table(time_filter, time_filter_data_type, metric_obj['metric'], metric_obj['config'], table_name) %}
         {% do table_expr.append({ 'expr': expression, 'col_name': '', 'metric': metric_obj['metric']}) %}
     {% endfor %}
 
@@ -51,18 +51,18 @@
 
 {% endmacro %}
 
-{% macro metrics_base_expression_table(time_filter, metric_name, config, table_name) %}
+{% macro metrics_base_expression_table(time_filter, time_filter_data_type, metric_name, config, table_name) %}
     {% set metric_macro = re_data.get_metric_macro(metric_name) %}
-    {% set context = {'time_filter': time_filter, 'metric_name': metric_name, 'config': config, 'table_name': table_name, 'column_name': none} %}
+    {% set context = {'time_filter': time_filter, 'time_filter_data_type': time_filter_data_type, 'metric_name': metric_name, 'config': config, 'table_name': table_name, 'column_name': none} %}
 
     {{ metric_macro(context) }}
 
 {% endmacro %}
 
 
-{%- macro metrics_base_expression_column(column_name, metric_name, config, table_name, time_filter) %}
+{%- macro metrics_base_expression_column(column_name, metric_name, config, table_name, time_filter, time_filter_data_type) %}
     {% set metric_macro = re_data.get_metric_macro(metric_name) %}
-    {% set context = {'time_filter': time_filter, 'metric_name': metric_name, 'config': config, 'table_name': table_name, 'column_name': re_data.quote_column_name(column_name)} %}
+    {% set context = {'time_filter': time_filter, 'time_filter_data_type': time_filter_data_type, 'metric_name': metric_name, 'config': config, 'table_name': table_name, 'column_name': re_data.quote_column_name(column_name)} %}
 
     {{ metric_macro(context) }}
 

--- a/macros/metrics/base/queries.sql
+++ b/macros/metrics/base/queries.sql
@@ -8,6 +8,7 @@
             {% set schema = re_data.row_value(mtable, 'schema') %}
             {% set database = re_data.row_value(mtable, 'database') %}
             {% set time_filter = re_data.row_value(mtable, 'time_filter') %}    
+            {% set time_filter_data_type = re_data.row_value(mtable, 'time_filter_data_type') %}
             {% set metrics = fromjson(re_data.row_value(mtable, 'metrics')) %}
             {% set for_cols = fromjson(re_data.row_value(mtable, 'columns')) %}
             {% set for_cols_dict = re_data.dict_from_list(for_cols) %}
@@ -39,7 +40,7 @@
 
                 {% if columns_size == var('re_data:max_columns_in_query') %}
                 {# /* Some balance size between making sure query will not crash &  */ #}
-                    {%- set insert_stats_query = re_data.metrics_base_insert(table_name, time_filter, metrics, ref_model, columns_to_query) -%}
+                    {%- set insert_stats_query = re_data.metrics_base_insert(table_name, time_filter, time_filter_data_type, metrics, ref_model, columns_to_query) -%}
 
                     {% if insert_stats_query %}
                         {% do run_query(insert_stats_query) %}
@@ -48,7 +49,7 @@
                 {% endif %}
             {% endfor %}
 
-            {%- set insert_stats_query = re_data.metrics_base_insert(table_name, time_filter, metrics, ref_model, columns_to_query, table_level=True) -%}
+            {%- set insert_stats_query = re_data.metrics_base_insert(table_name, time_filter, time_filter_data_type, metrics, ref_model, columns_to_query, table_level=True) -%}
             {% do run_query(insert_stats_query) %}
 
             {{ dbt_utils.log_info('[re_data_log] - finished computing metrics for table:' ~ table_name) }}
@@ -56,9 +57,9 @@
     {% endfor %}
 {% endmacro %}
 
-{% macro metrics_base_insert(table_name, time_filter, metrics, ref_model, columns, table_level=False) %}
+{% macro metrics_base_insert(table_name, time_filter, time_filter_data_type, metrics, ref_model, columns, table_level=False) %}
 
-    {% set col_exprs = re_data.metrics_base_expressions(table_name, time_filter, metrics, columns, table_level) %}
+    {% set col_exprs = re_data.metrics_base_expressions(table_name, time_filter, time_filter_data_type, metrics, columns, table_level) %}
     {% if col_exprs == [] %}
         {{ return ('') }}
     {% endif %}

--- a/macros/utils/time_macros.sql
+++ b/macros/utils/time_macros.sql
@@ -1,11 +1,19 @@
 
-{% macro time_window_start() %}
-    cast('{{- var('re_data:time_window_start') -}}' as timestamp) 
+{% macro time_window_start(time_column_data_type = none) %}
+    {% if time_column_data_type is none %}
+        cast('{{- var('re_data:time_window_start') -}}' as TIMESTAMP)
+    {% else %}
+        cast('{{- var('re_data:time_window_start') -}}' as '{{- time_column_data_type -}}')
+    {% endif %}
 {% endmacro %}
 
 
-{% macro time_window_end() %}
-    cast('{{- var('re_data:time_window_end') -}}' as timestamp)
+{% macro time_window_end(time_column_data_type = none) %}
+    {% if time_column_data_type is none %}
+        cast('{{- var('re_data:time_window_end') -}}' as TIMESTAMP)
+    {% else %}
+        cast('{{- var('re_data:time_window_end') -}}' as '{{- time_column_data_type -}}')
+    {% endif %}
 {% endmacro %}
 
 
@@ -46,23 +54,18 @@
    DATEDIFF(second, {{ start_timestamp }}, {{ end_timestamp }})
 {% endmacro %}
 
-{%- macro in_time_window(time_column) %}
+{%- macro in_time_window(time_column, time_column_data_type) %}
     {# /* If not time_filter is specified, we compute the metric over the entire table else we filter for the time frame */ #}
     {% if time_column is none %}
             true
     {% else %}
-        {{ adapter.dispatch('in_time_window', 're_data')(time_column) }}
+        {{ adapter.dispatch('in_time_window', 're_data')(time_column, time_column_data_type) }}
     {% endif %}
 {% endmacro -%}
 
-{% macro default__in_time_window(time_column) %}
-    {{time_column}} >= {{ time_window_start() }} and
-    {{time_column}} < {{ time_window_end() }}
-{% endmacro %}
-
-{% macro bigquery__in_time_window(time_column) %}
-    timestamp({{time_column}}) >= {{ time_window_start() }} and
-    timestamp({{time_column}}) < {{ time_window_end() }}
+{% macro default__in_time_window(time_column, time_column_data_type) %}
+    {{time_column}} >= {{ time_window_start(time_column_data_type) }} and
+    {{time_column}} < {{ time_window_end(time_column_data_type) }}
 {% endmacro %}
 
 

--- a/models/meta/re_data_monitored.sql
+++ b/models/meta/re_data_monitored.sql
@@ -12,6 +12,7 @@
         ('schema', 'string'),
         ('database', 'string'),
         ('time_filter', 'string'),
+        ('time_filter_data_type', 'string'),
         ('metrics', 'string'),
         ('columns', 'string'),
         ('anomaly_detector', 'string'),

--- a/models/meta/re_data_selected.sql
+++ b/models/meta/re_data_selected.sql
@@ -1,6 +1,6 @@
 
 select 
-    name, schema, database, time_filter, metrics, columns, anomaly_detector, owners
+    name, schema, database, time_filter, time_filter_data_type, metrics, columns, anomaly_detector, owners
 from {{ ref('re_data_monitored')}}
 where 
     selected = true


### PR DESCRIPTION
## What
Solves https://github.com/re-data/re-data/issues/313

## How
We are looking for a better way to flexibly deal with different column data type of `re_data_time_filter `. At re_data 0.9.2, the data type is casted to `timestamp` by default. What if we can pass the data type with the new configuration `re_data_time_filter_data_type`?
