### PR TITLE
Enable to calculate metrics of a partitioned table in BigQuery

### DIFF
--- a/macros/utils/time_macros.sql
+++ b/macros/utils/time_macros.sql
@@ -61,8 +61,8 @@
 {% endmacro %}
 
 {% macro bigquery__in_time_window(time_column) %}
-    timestamp({{time_column}}) >= {{ time_window_start() }} and
-    timestamp({{time_column}}) < {{ time_window_end() }}
+    safe_cast({{time_column}} as timestamp) >= {{ time_window_start() }} and
+    safe_cast({{time_column}} as timestamp) < {{ time_window_end() }}
 {% endmacro %}
 
 


### PR DESCRIPTION
## What
Solves https://github.com/re-data/re-data/issues/313

## How
The `SAFE_CAST` function enables us to calculate metrics even of a partitioned table in BigQuery.
