### PR TITLE
escape newline characters in json values

### DIFF
--- a/macros/utils/agate/row_value.sql
+++ b/macros/utils/agate/row_value.sql
@@ -10,7 +10,7 @@
         {% set pairs = [] %}
         {% for col_name in col_names %}
             {% set value = row.get(col_name) | string %}
-            {% do pairs.append('"' ~ (col_name | lower) ~ '":' ~ '"' ~ (value | replace('"', '\\\"') ) ~ '"') %}
+            {% do pairs.append('"' ~ (col_name | lower) ~ '":' ~ '"' ~ (value | replace('"', '\\\"') | replace('\n', '\\n') ) ~ '"') %}
         {% endfor %}
         {% set joined_pairs = '{' ~ (pairs | join(',')) ~ '}' %}
         {% do query_result.append(joined_pairs) %}


### PR DESCRIPTION
## What
When serializing to json with jinja, we realized that the value could contain a json object formatted with newlines, so we need to escape those newlines to ensure validity of the final json.

## How
Escape newline special character (`\n`) in `agate_to_list` macro
