### PR TITLE
add casting feature to insert_list_to_table and utilize it for run_at…

### DIFF
--- a/macros/run_end/save_results_history.sql
+++ b/macros/run_end/save_results_history.sql
@@ -20,7 +20,8 @@
             {% do re_data.insert_list_to_table(
                 ref('re_data_test_history'),
                 tests,
-                ['table_name', 'column_name', 'test_name', 'status', 'execution_time', 'message', 'failures_count', 'failures_json', 'failures_table', 'severity', 'compiled_sql', 'run_at']
+                ['table_name', 'column_name', 'test_name', 'status', 'execution_time', 'message', 'failures_count', 'failures_json', 'failures_table', 'severity', 'compiled_sql', 'run_at'],
+                { 'run_at': timestamp_type() }
             ) %}
         {% endif %}
 

--- a/macros/store/insert_list_to_table.sql
+++ b/macros/store/insert_list_to_table.sql
@@ -1,4 +1,4 @@
-{% macro insert_list_to_table(table, list, params, insert_size=100) %}
+{% macro insert_list_to_table(table, list, params, dtype=None,insert_size=100) %}
 
     {% set single_insert_list = [] %}
     {% for el in list %}
@@ -15,7 +15,12 @@
                             NULL
                         {%- else -%}
                             {%- if row[p] is string -%}
-                                {{- re_data.quote_string(row[p]) -}}
+                                {%- if dtype and p in dtype -%}
+                                  {% set cast_type = dtype[p] %}
+                                  cast ({{ re_data.quote_string(row[p]) }} as {{ cast_type }})
+                                {%- else %}
+                                  {{- re_data.quote_string(row[p]) -}}
+                                {%- endif -%}
                             {%- elif row[p] is number -%}
                                 {{-row[p]-}}
                             {%- else -%}


### PR DESCRIPTION
## What
When saving test result to DB, some DB does not cast string to timestamp automatically causes the query to fail.

## How
- add casting feature to `insert_list_to_table` by an extra dtype dict
- and use that to cast `run_at` in `save_results_history`
