### PR TITLE
Apply time frame limit condition from both ends for all type of alerts

### DIFF
--- a/macros/public/store/export_alerts.sql
+++ b/macros/public/store/export_alerts.sql
@@ -8,10 +8,7 @@
             {{ format_timestamp('time_window_end')}} as {{ re_data.quote_column('time_window_end') }} 
         from {{ ref('re_data_alerts') }}
         where
-            case
-                when type = 'anomaly' then {{ in_date_window('time_window_end', start_date, end_date) }}
-                else {{ in_date_window('time_window_end', start_date, none) }}
-            end
+            {{ in_date_window('time_window_end', start_date, end_date) }}
         order by time_window_end desc
     {% endset %}
 


### PR DESCRIPTION
## What
*Describe what the change is solving*
Fixing [#344 [BUG] Slack notification prints test failures even though they had happened several days ago](https://github.com/re-data/re-data/issues/344)

## How
Apply time frame limit condition from both ends for all type of alerts
