### PR TITLE
update dbt-utils

### DIFF
--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -2,4 +2,4 @@ packages:
   - local: ../
 
   - package: dbt-labs/dbt_utils
-    version: [">=0.7.0", "<0.9.0"]
+    version: [">=0.7.0", "<0.10.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,4 @@
 
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.7.0", "<0.9.0"]
+    version: [">=0.7.0", "<0.10.0"]


### PR DESCRIPTION
## What
update dbt-utils to < 0.10.0. 
This introduces warning `Warning: the 'current_timestamp_in_utc' macro is deprecated and will be removed in a future version of the package, once equivalent functionality is implemented in dbt Core.`. The macro is removed from dbt-utils in beta 1.0.0-b2  version