### PR TITLE
add namespace to fivetran_utils macros, fix #103

### DIFF
--- a/macros/utils/fivetran_utils/json_extract.sql
+++ b/macros/utils/fivetran_utils/json_extract.sql
@@ -5,7 +5,7 @@
 
 {% macro json_extract(string, string_path) -%}
 
-{{ adapter.dispatch('json_extract') (string, string_path) }}
+{{ adapter.dispatch('json_extract','re_data') (string, string_path) }}
 
 {%- endmacro %}
 

--- a/macros/utils/fivetran_utils/percentile.sql
+++ b/macros/utils/fivetran_utils/percentile.sql
@@ -5,7 +5,7 @@
 
 {% macro percentile(percentile_field, partition_field, percent) -%}
 
-{{ adapter.dispatch('percentile') (percentile_field, partition_field, percent) }}
+{{ adapter.dispatch('percentile','re_data') (percentile_field, partition_field, percent) }}
 
 {%- endmacro %}
 


### PR DESCRIPTION
add `re_data` namespace to fivetran-utils macro in `macros/utils/fivetran_utils`
