### PR TITLE
use raw string in google bigquery to avoid parsing illegal escape characters

### DIFF
--- a/macros/db/bigquery/quote_string.sql
+++ b/macros/db/bigquery/quote_string.sql
@@ -1,4 +1,4 @@
 
 {%- macro bigquery__quote_string(str) %}
-    """{{ str }}"""
+    r"""{{ str }}"""
 {% endmacro %}


### PR DESCRIPTION
## What
* Fixes https://github.com/re-data/re-data/issues/370
* Reference to google big query docs: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals

## How
Using raw strings fixes the `dbt test` command on-run-end failures because all strings are now raw strings meaning backslash characters do not act as escape sequences
