### PR TITLE
fix save_test_history macro to work when a model depends_on a source with the same name

### DIFF
--- a/macros/run_end/save_results_history.sql
+++ b/macros/run_end/save_results_history.sql
@@ -40,15 +40,15 @@
 
         {% if any_refs %}
             {% set name = any_refs[0] %}
-            {% set node_name = re_data.priv_full_name_from_depends(el.node, name) %}
+            {% set node_name = re_data.priv_full_name_from_depends(el.node, name, "model") %}
             {% set schema = graph.nodes.get(node_name)['schema'] %}
             {% set database = graph.nodes.get(node_name)['database'] %}
-            {% set table_name = (database + '.' + schema + '.' + name) | lower %} 
-            
+            {% set table_name = (database + '.' + schema + '.' + name) | lower %}
+
         {% elif any_source %}
             {% set package_name = any_source[0][0] %}
             {% set name = any_source[0][1] %}
-            {% set node_name = re_data.priv_full_name_from_depends(el.node, name) %}
+            {% set node_name = re_data.priv_full_name_from_depends(el.node, name, "source") %}
             {% set schema = graph.sources.get(node_name)['schema'] %}
             {% set database = graph.sources.get(node_name)['database'] %}
             {% set table_name = (database + '.' + schema + '.' + name) | lower %}
@@ -98,11 +98,12 @@
 
 {% endmacro %}
 
-{% macro priv_full_name_from_depends(node, name) %}
+{% macro priv_full_name_from_depends(node, name, type) %}
 
     {% for full_name in node.depends_on.nodes %}
         {% set node_name = full_name.split('.')[-1] %}
-        {% if node_name == name %}
+        {% set node_type = full_name.split('.')[0] %}
+        {% if node_name == name and node_type == type %}
             {{ return(full_name) }}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
* Without checking the node_type, a model could match a source with the same name and the macro would error out trying to get the database on that node which is not present for a source
* Fixes issue: https://github.com/re-data/re-data/issues/371

## What
*Describe what the change is solving*
By comparing the type of the node, we can ensure that we fetch models for refs and sources for sources.

## How
passing the additional type parameter `priv_full_name_from_depends` fixes the failing error as it now fetches the correct full name for the corresponding source or model
