### PR TITLE
Use node.compiled_code for dbt-core>=v1.3.0

### DIFF
--- a/macros/run_end/save_results_history.sql
+++ b/macros/run_end/save_results_history.sql
@@ -91,7 +91,7 @@
         'failures_json': '' ~ failures_list,
         'failures_table': el.node.relation_name or none,
         'severity': el.node.config.severity,
-        'compiled_sql': el.node.compiled_sql or none,
+        'compiled_sql': el.node.compiled_sql or el.node.compiled_code or none,
         'run_at': run_started_at_str,
         })
     }}


### PR DESCRIPTION
## What
Fixes Issue : https://github.com/re-data/re-data/issues/397 (save_test_history macro doesn't store compiled_sql after dbt-core>=v1.3.0)

## How
By using the `node.compiled_sql` and `node.compiled_code` in an `or` condition so that the logic works with both `dbt-core<v1.3.0` and `dbt-core>=v1.3.0`.
