### PR TITLE
Feature/include additional runtime metadata in result history

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,6 +23,10 @@ vars:
 
   re_data:save_test_history: false
 
+  re_data:save_test_history_additional_runtime_metadata: 
+    vars: []
+    env_vars: []
+
   re_data:anomaly_detector:
     name: modified_z_score
     threshold: 3

--- a/macros/public/store/export_tests_history.sql
+++ b/macros/public/store/export_tests_history.sql
@@ -13,7 +13,8 @@
             failures_json, 
             failures_table,
             severity, 
-            compiled_sql
+            compiled_sql,
+            additional_runtime_metadata
         from
             {{ ref('re_data_test_history') }}
         where {{ in_date_window('run_at', start_date, end_date) }}

--- a/macros/run_end/save_results_history.sql
+++ b/macros/run_end/save_results_history.sql
@@ -20,7 +20,7 @@
             {% do re_data.insert_list_to_table(
                 ref('re_data_test_history'),
                 tests,
-                ['table_name', 'column_name', 'test_name', 'status', 'execution_time', 'message', 'tested_records_count' ,'failures_count', 'failures_json', 'failures_table', 'severity', 'compiled_sql', 'run_at'],
+                ['table_name', 'column_name', 'test_name', 'status', 'execution_time', 'message', 'tested_records_count' ,'failures_count', 'failures_json', 'failures_table', 'severity', 'compiled_sql', 'run_at','additional_runtime_metadata'],
                 { 'run_at': timestamp_type() }
             ) %}
         {% endif %}
@@ -91,6 +91,21 @@
     {% else %}
         {% set tested_records_count = none %}
     {% endif %}
+    
+    {% if var.has_var('re_data:save_test_history_additional_runtime_metadata') %}
+        {% set additional_runtime_metadata = {} %}
+        {% for _var in var('re_data:save_test_history_additional_runtime_metadata').get('vars') %}
+            {% if var.has_var(_var) %}
+                {% do additional_runtime_metadata.update({_var:var(_var)}) %}
+            {% endif %}
+        {% endfor %}      
+        {% for _env_var in var('re_data:save_test_history_additional_runtime_metadata').get('env_vars') %}
+            {% if env_var(_env_var,'')|length>0 %}
+                {% do additional_runtime_metadata.update({_env_var:env_var(_env_var)}) %}
+            {% endif %}
+        {% endfor %}
+        {% set additional_runtime_metadata = tojson(additional_runtime_metadata) %}
+    {% endif %}
 
     {{ return ({
         'table_name': table_name,
@@ -106,6 +121,7 @@
         'severity': el.node.config.severity,
         'compiled_sql': el.node.compiled_sql or el.node.compiled_code or none,
         'run_at': run_started_at_str,
+        'additional_runtime_metadata': additional_runtime_metadata or none
         })
     }}
 

--- a/models/logs/re_data_test_history.sql
+++ b/models/logs/re_data_test_history.sql
@@ -19,6 +19,7 @@
         ('failures_table', 'long_string'),
         ('severity', 'string'),
         ('compiled_sql', 'long_string'),
-        ('run_at', 'timestamp')
+        ('run_at', 'timestamp'),
+        ('additional_runtime_metadata', 'long_string')
     ])
 }}


### PR DESCRIPTION
## What
This RP allows include additional runtime metadata in test result history. This can be vars and env variables

## How
The macro save_results_history reads the configured additional runtime metadata and stores them in additional_runtime_metadata column