### PR TITLE
Bump versions for dbt_utils and dbt-core

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: "re_data"
 version: "0.10.7"
 config-version: 2
 
-require-dbt-version: [">=1.0.0", "<1.5.0"]
+require-dbt-version: [">=1.0.0", "<1.6.0"]
 
 profile: "re_data_postgres"
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,4 @@
 
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=1.0.0", "<1.1.0"]
+    version: [">=1.0.0", "<1.2.0"]


### PR DESCRIPTION
I was trying to upgrade our project to dbt-core 1.5, but realised that re-data versions were not compatible. No actual code changes were required, just bumping the allowed versions.