### PR TITLE
add re_data_anomalies_filtered as var

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,7 +18,7 @@ vars:
   re_data:time_window_start: '{{ (run_started_at - modules.datetime.timedelta(1)).strftime("%Y-%m-%d 00:00:00") }}'
   re_data:anomaly_detection_look_back_days: 30
   re_data:select: null
-  re_data:re_data_anomalies_filtered: {{ ref('re_data_anomalies') }}
+  re_data:re_data_anomalies_filtered: re_data_anomalies
 
   re_data:alerting_z_score: 3
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,6 +18,7 @@ vars:
   re_data:time_window_start: '{{ (run_started_at - modules.datetime.timedelta(1)).strftime("%Y-%m-%d 00:00:00") }}'
   re_data:anomaly_detection_look_back_days: 30
   re_data:select: null
+  re_data:re_data_anomalies_filtered: {{ ref('re_data_anomalies') }}
 
   re_data:alerting_z_score: 3
 

--- a/models/alerts/re_data_alerts.sql
+++ b/models/alerts/re_data_alerts.sql
@@ -5,7 +5,7 @@ select
     last_value_text as value,
     time_window_end
 from
-    {{ ref('re_data_anomalies') }}
+    {{ var('re_data_anomalies_filtered') }}
 union all
 
 select

--- a/models/alerts/re_data_alerts.sql
+++ b/models/alerts/re_data_alerts.sql
@@ -5,7 +5,7 @@ select
     last_value_text as value,
     time_window_end
 from
-    {{ var('re_data_anomalies_filtered') }}
+    {{ ref(var('re_data:re_data_anomalies_filtered')) }}
 union all
 
 select


### PR DESCRIPTION
## What
closes https://github.com/re-data/re-data/issues/403

## How
Add a var for `re_data_anomalies_filtered` that can override the alerts. In this way, you can select from `re_data_anomalies` what anomalies you would like to show in alerts in the UI, and also notify in slack.

After this change, the user can create a model (view, ephemeral, table, anything works) on top of `re_data_anomalies`, for example, the view `anomaly_filters`

```
 SELECT
        *
    FROM
        {{ ref('re_data_anomalies') }}
    WHERE
        table_name LIKE '%my_test_table%'
        AND column_name = 'age'
        AND metric = 'avg'
```
Then set up re_data:re_data_anomalies_filtered: anomaly_filters` in `dbt.project.yml` and that is all.

------------
Tried it on my current project by loading
```
packages:  
  - git: https://github.com/suelai/dbt-re-data.git
    revision: b1c137c6bd807e06002b7bba1699a0a05deff8ff
```
and then set up   `re_data:re_data_anomalies_filtered: anomaly_filters` in my `dbt_project.yml` where `anomaly_filters` is an ephemeral model on top of `re_data_anomalies`
It worked as expected and `re_data_alerts` is now filtered on `anomaly_filters`