### PR TITLE
add boolean and boolean metrics

### DIFF
--- a/macros/metrics/base/build_in/column_default.sql
+++ b/macros/metrics/base/build_in/column_default.sql
@@ -64,4 +64,28 @@
     {{ percentage_formula(re_data_metric_missing_count(context), re_data_metric_row_count()) }}
 {% endmacro %}
 
+{% macro re_data_metric_count_true(context) %}
+    COALESCE(
+        SUM(
+            CASE
+                WHEN {{ context.column_name }} IS TRUE THEN 1
+                ELSE 0
+            END
+        ),
+        0
+    )
+{% endmacro %}
+
+{% macro re_data_metric_count_false(context) %}
+    COALESCE(
+        SUM(
+            CASE
+                WHEN {{ context.column_name }} IS FALSE THEN 1
+                ELSE 0
+            END
+        ),
+        0
+    )
+{% endmacro %}
+
 

--- a/macros/utils/column_types.sql
+++ b/macros/utils/column_types.sql
@@ -27,6 +27,10 @@
             'enum',
         ] %}
         {{ return('numeric') }}
+    
+    {% elif column.data_type in [ 'boolean', 'bool' ] %}
+    
+        {{ return('boolean') }}
 
     {% else %}
         {{ return('unknown') }}
@@ -67,6 +71,10 @@
     ] %}
 
         {{ return('numeric') }}
+
+    {% elif column.data_type in [ 'BOOLEAN' ] %}
+    
+        {{ return('boolean') }}
 
     {% else %}
 

--- a/macros/utils/column_types.sql
+++ b/macros/utils/column_types.sql
@@ -78,23 +78,17 @@
 
 
 {% macro bigquery__get_column_type(column) %}
-    
-    {% if column.data_type in [
-        'STRING'
-    ] %}
 
+    {% if column.data_type in [ 'STRING' ] %}
         {{ return('text') }}
 
-    {% elif column.data_type in [
-        "INT64", "NUMERIC", "BIGNUMERIC", "FLOAT64", "INTEGER"]
-    %}
-
+        {% elif column.data_type in [ "INT64", "NUMERIC", "BIGNUMERIC", "FLOAT64", "INTEGER"] %}
         {{ return('numeric') }}
 
+        {% elif column.data_type in [ "BOOLEAN", "BOOL"] %}
+        {{ return('boolean') }}
     {% else %}
-    
         {{ return('unknown') }}
 
     {% endif %}
-
 {% endmacro %}


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

Get counts of `TRUE` and `FALSE` for boolean values. Right now the column type are text and numeric only
change the macros that detect the column types for BigQuery to recognise booleans and add two metrics of `count_true` and `count_false`

## How
*Describe the solution*

Add an if condition to `bigquery__get_column_type` to include the `boolean` column type. Add two metrics of count_true` and `count_false`

relates to https://github.com/re-data/re-data/issues/405
