### PR TITLE
Specific anomaly tuning for colums

### DIFF
--- a/macros/meta/get_column_specific_config.sql
+++ b/macros/meta/get_column_specific_config.sql
@@ -1,0 +1,20 @@
+{% macro get_column_specific_anomaly(
+    database, schema, column_name, table_name, metric_name
+) %}
+    {% set column_path = "column." ~ column_name %}
+    select
+        name as table_name,
+        schema as schema,
+        database as database,
+        {{ "'" ~ column_name ~ "'" }} as column_name,
+        {{ "'" ~ metric_name ~ "'" }} as metric_name,
+        json_query(t, {{ "'$." ~ metric_name ~ "'" }}) as metric_spec
+    from
+        {{ ref("re_data_selected") }},
+        unnest({{ re_data.json_extract_array("additional_metrics", column_path) }}) t
+    where
+        name = {{ "'" ~ table_name ~ "'" }}
+        and schema = {{ "'" ~ schema ~ "'" }}
+        and database = {{ "'" ~ database ~ "'" }}
+
+{% endmacro %}

--- a/macros/meta/get_column_specific_config.sql
+++ b/macros/meta/get_column_specific_config.sql
@@ -3,10 +3,10 @@
 ) %}
     {% set column_path = "column." ~ column_name %}
     select
-        name as table_name,
+        name as name,
         schema as schema,
         database as database,
-        {{ "'" ~ column_name ~ "'" }} as column_name,
+        {{ "'" ~ column_name ~ "'" }} as column,
         {{ "'" ~ metric_name ~ "'" }} as metric_name,
         json_query(t, {{ "'$." ~ metric_name ~ "'" }}) as metric_spec
     from

--- a/macros/utils/anomaly_labeling.sql
+++ b/macros/utils/anomaly_labeling.sql
@@ -77,3 +77,138 @@
         else false
     end
 {% endmacro %}
+
+
+{% macro is_anomaly_from_column(
+    anomaly_config,
+    last_value,
+    last_avg,
+    z_score_value,
+    modified_z_score_value,
+    last_first_quartile,
+    last_iqr,
+    last_third_quartile
+) %}
+    case
+        when
+            (
+                lower(
+                    coalesce(
+                        {{
+                            json_extract(
+                                anomaly_config,
+                                "re_data_anomaly_detector.direction",
+                            )
+                        }},
+                        'both'
+                    )
+                )
+                = 'up'
+                and {{ last_value }} > {{ last_avg }}
+            )
+            or (
+                lower(
+                    coalesce(
+                        {{
+                            json_extract(
+                                anomaly_config,
+                                "re_data_anomaly_detector.direction",
+                            )
+                        }},
+                        'both'
+                    )
+                )
+                = 'down'
+                and {{ last_value }} < {{ last_avg }}
+            )
+            or (
+                lower(
+                    coalesce(
+                        {{
+                            json_extract(
+                                anomaly_config,
+                                "re_data_anomaly_detector.direction",
+                            )
+                        }},
+                        'both'
+                    )
+                )
+                != 'up'
+                and lower(
+                    coalesce(
+                        {{
+                            json_extract(
+                                anomaly_config,
+                                "re_data_anomaly_detector.direction",
+                            )
+                        }},
+                        'both'
+                    )
+                )
+                != 'down'
+            )
+        then
+            case
+                when
+                    {{ json_extract(anomaly_config, "re_data_anomaly_detector.name") }}
+                    = 'z_score'
+                then
+                    abs({{ z_score_value }}) > cast(
+                        {{
+                            json_extract(
+                                anomaly_config,
+                                "re_data_anomaly_detector.threshold",
+                            )
+                        }} as {{ numeric_type() }}
+                    )
+                when
+                    {{ json_extract(anomaly_config, "re_data_anomaly_detector.name") }}
+                    = 'modified_z_score'
+                then
+                    abs({{ modified_z_score_value }}) > cast(
+                        {{
+                            json_extract(
+                                anomaly_config,
+                                "re_data_anomaly_detector.threshold",
+                            )
+                        }} as {{ numeric_type() }}
+                    )
+                when
+                    {{ json_extract(anomaly_config, "re_data_anomaly_detector.name") }}
+                    = 'boxplot'
+                then
+                    (
+                        {{ last_value }}
+                        < {{ last_first_quartile }}
+                        - (
+                            cast(
+                                {{
+                                    json_extract(
+                                        anomaly_config,
+                                        "re_data_anomaly_detector.whisker_boundary_multiplier",
+                                    )
+                                }}
+                                as {{ numeric_type() }}
+                            )
+                            * {{ last_iqr }}
+                        )
+                        or {{ last_value }}
+                        > {{ last_third_quartile }}
+                        + (
+                            cast(
+                                {{
+                                    json_extract(
+                                        anomaly_config,
+                                        "re_data_anomaly_detector.whisker_boundary_multiplier",
+                                    )
+                                }}
+                                as {{ numeric_type() }}
+                            )
+                            * {{ last_iqr }}
+                        )
+                    )
+                else false
+            end
+        else false
+    end
+{% endmacro %}

--- a/macros/utils/anomaly_labeling.sql
+++ b/macros/utils/anomaly_labeling.sql
@@ -1,79 +1,86 @@
-{% macro is_anomaly_from_model(
-    anomaly_config,
-    last_value,
-    last_avg,
-    z_score_value,
-    modified_z_score_value,
-    last_first_quartile,
-    last_iqr,
-    last_third_quartile
-) %}
+{{ config(materialized="view") }}
+select
+    z.id,
+    z.table_name,
+    z.column_name,
+    z.metric,
+    z.z_score_value,
+    z.modified_z_score_value,
+    m.anomaly_detector,
+    c.metric_spec,
+    z.last_value,
+    z.last_avg,
+    z.last_median,
+    z.last_stddev,
+    z.last_median_absolute_deviation,
+    z.last_mean_absolute_deviation,
+    z.last_iqr,
+    z.last_first_quartile - (
+        cast(
+            {{ json_extract("m.anomaly_detector", "whisker_boundary_multiplier") }}
+            as {{ numeric_type() }}
+        )
+        * z.last_iqr
+    ) lower_bound,
+    z.last_third_quartile + (
+        cast(
+            {{ json_extract("m.anomaly_detector", "whisker_boundary_multiplier") }}
+            as {{ numeric_type() }}
+        )
+        * z.last_iqr
+    ) upper_bound,
+    z.last_first_quartile,
+    z.last_third_quartile,
+    z.time_window_end,
+    z.interval_length_sec,
+    z.computed_on,
+    {{
+        re_data.generate_anomaly_message(
+            "z.column_name", "z.metric", "z.last_value", "z.last_avg"
+        )
+    }} as message,
+    {{ re_data.generate_metric_value_text("z.metric", "z.last_value") }}
+    as last_value_text
+from {{ ref("re_data_z_score") }} z
+left join
+    {{ ref("re_data_selected") }} m
+    on {{ split_and_return_nth_value("table_name", ".", 1) }} = m.database
+    and {{ split_and_return_nth_value("table_name", ".", 2) }} = m.schema
+    and {{ split_and_return_nth_value("table_name", ".", 3) }} = m.name
+left join
+    {{ ref("re_data_selected_columns") }} c
+    on {{ split_and_return_nth_value("table_name", ".", 1) }} = c.database
+    and {{ split_and_return_nth_value("table_name", ".", 2) }} = c.schema
+    and {{ split_and_return_nth_value("table_name", ".", 3) }} = c.name
+    and z.column_name = c.column
+where
     case
-        when
-            (
-                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
-                = 'up'
-                and {{ last_value }} > {{ last_avg }}
-            )
-            or (
-                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
-                = 'down'
-                and {{ last_value }} < {{ last_avg }}
-            )
-            or (
-                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
-                != 'up'
-                and lower(
-                    coalesce({{ json_extract(anomaly_config, "direction") }}, 'both')
-                )
-                != 'down'
-            )
+        when c.metric_spec is not null
         then
-            case
-                when {{ json_extract(anomaly_config, "name") }} = 'z_score'
-                then
-                    abs({{ z_score_value }}) > cast(
-                        {{ json_extract(anomaly_config, "threshold") }}
-                        as {{ numeric_type() }}
-                    )
-                when {{ json_extract(anomaly_config, "name") }} = 'modified_z_score'
-                then
-                    abs({{ modified_z_score_value }}) > cast(
-                        {{ json_extract(anomaly_config, "threshold") }}
-                        as {{ numeric_type() }}
-                    )
-                when {{ json_extract(anomaly_config, "name") }} = 'boxplot'
-                then
-                    (
-                        {{ last_value }}
-                        < {{ last_first_quartile }}
-                        - (
-                            cast(
-                                {{
-                                    json_extract(
-                                        anomaly_config,
-                                        "whisker_boundary_multiplier",
-                                    )
-                                }} as {{ numeric_type() }}
-                            )
-                            * {{ last_iqr }}
-                        )
-                        or {{ last_value }}
-                        > {{ last_third_quartile }}
-                        + (
-                            cast(
-                                {{
-                                    json_extract(
-                                        anomaly_config,
-                                        "whisker_boundary_multiplier",
-                                    )
-                                }} as {{ numeric_type() }}
-                            )
-                            * {{ last_iqr }}
-                        )
-                    )
-                else false
-            end
-        else false
+            {{
+                is_anomaly_from_model(
+                    anomaly_config="c.metric_spec",
+                    last_value="z.last_value",
+                    last_avg="z.last_avg",
+                    z_score_value="z.z_score_value",
+                    modified_z_score_value="z.modified_z_score_value",
+                    last_first_quartile="z.last_first_quartile",
+                    last_iqr="z.last_iqr",
+                    last_third_quartile="z.last_third_quartile",
+                )
+            }}
+        else
+            {{
+                is_anomaly_from_model(
+                    anomaly_config="m.anomaly_detector",
+                    last_value="z.last_value",
+                    last_avg="z.last_avg",
+                    z_score_value="z.z_score_value",
+                    modified_z_score_value="z.modified_z_score_value",
+                    last_first_quartile="z.last_first_quartile",
+                    last_iqr="z.last_iqr",
+                    last_third_quartile="z.last_third_quartile",
+                )
+            }}
+
     end
-{% endmacro %}

--- a/macros/utils/anomaly_labeling.sql
+++ b/macros/utils/anomaly_labeling.sql
@@ -1,86 +1,79 @@
-{{ config(materialized="view") }}
-select
-    z.id,
-    z.table_name,
-    z.column_name,
-    z.metric,
-    z.z_score_value,
-    z.modified_z_score_value,
-    m.anomaly_detector,
-    c.metric_spec,
-    z.last_value,
-    z.last_avg,
-    z.last_median,
-    z.last_stddev,
-    z.last_median_absolute_deviation,
-    z.last_mean_absolute_deviation,
-    z.last_iqr,
-    z.last_first_quartile - (
-        cast(
-            {{ json_extract("m.anomaly_detector", "whisker_boundary_multiplier") }}
-            as {{ numeric_type() }}
-        )
-        * z.last_iqr
-    ) lower_bound,
-    z.last_third_quartile + (
-        cast(
-            {{ json_extract("m.anomaly_detector", "whisker_boundary_multiplier") }}
-            as {{ numeric_type() }}
-        )
-        * z.last_iqr
-    ) upper_bound,
-    z.last_first_quartile,
-    z.last_third_quartile,
-    z.time_window_end,
-    z.interval_length_sec,
-    z.computed_on,
-    {{
-        re_data.generate_anomaly_message(
-            "z.column_name", "z.metric", "z.last_value", "z.last_avg"
-        )
-    }} as message,
-    {{ re_data.generate_metric_value_text("z.metric", "z.last_value") }}
-    as last_value_text
-from {{ ref("re_data_z_score") }} z
-left join
-    {{ ref("re_data_selected") }} m
-    on {{ split_and_return_nth_value("table_name", ".", 1) }} = m.database
-    and {{ split_and_return_nth_value("table_name", ".", 2) }} = m.schema
-    and {{ split_and_return_nth_value("table_name", ".", 3) }} = m.name
-left join
-    {{ ref("re_data_selected_columns") }} c
-    on {{ split_and_return_nth_value("table_name", ".", 1) }} = c.database
-    and {{ split_and_return_nth_value("table_name", ".", 2) }} = c.schema
-    and {{ split_and_return_nth_value("table_name", ".", 3) }} = c.name
-    and z.column_name = c.column
-where
+{% macro is_anomaly_from_model(
+    anomaly_config,
+    last_value,
+    last_avg,
+    z_score_value,
+    modified_z_score_value,
+    last_first_quartile,
+    last_iqr,
+    last_third_quartile
+) %}
     case
-        when c.metric_spec is not null
+        when
+            (
+                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
+                = 'up'
+                and {{ last_value }} > {{ last_avg }}
+            )
+            or (
+                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
+                = 'down'
+                and {{ last_value }} < {{ last_avg }}
+            )
+            or (
+                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
+                != 'up'
+                and lower(
+                    coalesce({{ json_extract(anomaly_config, "direction") }}, 'both')
+                )
+                != 'down'
+            )
         then
-            {{
-                is_anomaly_from_model(
-                    anomaly_config="c.metric_spec",
-                    last_value="z.last_value",
-                    last_avg="z.last_avg",
-                    z_score_value="z.z_score_value",
-                    modified_z_score_value="z.modified_z_score_value",
-                    last_first_quartile="z.last_first_quartile",
-                    last_iqr="z.last_iqr",
-                    last_third_quartile="z.last_third_quartile",
-                )
-            }}
-        else
-            {{
-                is_anomaly_from_model(
-                    anomaly_config="m.anomaly_detector",
-                    last_value="z.last_value",
-                    last_avg="z.last_avg",
-                    z_score_value="z.z_score_value",
-                    modified_z_score_value="z.modified_z_score_value",
-                    last_first_quartile="z.last_first_quartile",
-                    last_iqr="z.last_iqr",
-                    last_third_quartile="z.last_third_quartile",
-                )
-            }}
-
+            case
+                when {{ json_extract(anomaly_config, "name") }} = 'z_score'
+                then
+                    abs({{ z_score_value }}) > cast(
+                        {{ json_extract(anomaly_config, "threshold") }}
+                        as {{ numeric_type() }}
+                    )
+                when {{ json_extract(anomaly_config, "name") }} = 'modified_z_score'
+                then
+                    abs({{ modified_z_score_value }}) > cast(
+                        {{ json_extract(anomaly_config, "threshold") }}
+                        as {{ numeric_type() }}
+                    )
+                when {{ json_extract(anomaly_config, "name") }} = 'boxplot'
+                then
+                    (
+                        {{ last_value }}
+                        < {{ last_first_quartile }}
+                        - (
+                            cast(
+                                {{
+                                    json_extract(
+                                        anomaly_config,
+                                        "whisker_boundary_multiplier",
+                                    )
+                                }} as {{ numeric_type() }}
+                            )
+                            * {{ last_iqr }}
+                        )
+                        or {{ last_value }}
+                        > {{ last_third_quartile }}
+                        + (
+                            cast(
+                                {{
+                                    json_extract(
+                                        anomaly_config,
+                                        "whisker_boundary_multiplier",
+                                    )
+                                }} as {{ numeric_type() }}
+                            )
+                            * {{ last_iqr }}
+                        )
+                    )
+                else false
+            end
+        else false
     end
+{% endmacro %}

--- a/macros/utils/anomaly_labeling.sql
+++ b/macros/utils/anomaly_labeling.sql
@@ -1,0 +1,79 @@
+{% macro is_anomaly_from_model(
+    anomaly_config,
+    last_value,
+    last_avg,
+    z_score_value,
+    modified_z_score_value,
+    last_first_quartile,
+    last_iqr,
+    last_third_quartile
+) %}
+    case
+        when
+            (
+                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
+                = 'up'
+                and {{ last_value }} > {{ last_avg }}
+            )
+            or (
+                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
+                = 'down'
+                and {{ last_value }} < {{ last_avg }}
+            )
+            or (
+                lower(coalesce({{ json_extract(anomaly_config, "direction") }}, 'both'))
+                != 'up'
+                and lower(
+                    coalesce({{ json_extract(anomaly_config, "direction") }}, 'both')
+                )
+                != 'down'
+            )
+        then
+            case
+                when {{ json_extract(anomaly_config, "name") }} = 'z_score'
+                then
+                    abs({{ z_score_value }}) > cast(
+                        {{ json_extract(anomaly_config, "threshold") }}
+                        as {{ numeric_type() }}
+                    )
+                when {{ json_extract(anomaly_config, "name") }} = 'modified_z_score'
+                then
+                    abs({{ modified_z_score_value }}) > cast(
+                        {{ json_extract(anomaly_config, "threshold") }}
+                        as {{ numeric_type() }}
+                    )
+                when {{ json_extract(anomaly_config, "name") }} = 'boxplot'
+                then
+                    (
+                        {{ last_value }}
+                        < {{ last_first_quartile }}
+                        - (
+                            cast(
+                                {{
+                                    json_extract(
+                                        anomaly_config,
+                                        "whisker_boundary_multiplier",
+                                    )
+                                }} as {{ numeric_type() }}
+                            )
+                            * {{ last_iqr }}
+                        )
+                        or {{ last_value }}
+                        > {{ last_third_quartile }}
+                        + (
+                            cast(
+                                {{
+                                    json_extract(
+                                        anomaly_config,
+                                        "whisker_boundary_multiplier",
+                                    )
+                                }} as {{ numeric_type() }}
+                            )
+                            * {{ last_iqr }}
+                        )
+                    )
+                else false
+            end
+        else false
+    end
+{% endmacro %}

--- a/macros/utils/fivetran_utils/json_extract.sql
+++ b/macros/utils/fivetran_utils/json_extract.sql
@@ -2,39 +2,61 @@
 # This file contains significant part of code derived from 
 # https://github.com/fivetran/dbt_fivetran_utils/tree/v0.4.0 which is licensed under Apache License 2.0.
 #}
-
 {% macro json_extract(string, string_path) -%}
 
-{{ adapter.dispatch('json_extract','re_data') (string, string_path) }}
+    {{ adapter.dispatch("json_extract", "re_data")(string, string_path) }}
 
 {%- endmacro %}
 
 {% macro default__json_extract(string, string_path) %}
 
-  json_extract_path_text({{string}}, {{ "'" ~ string_path ~ "'" }} )
- 
+    json_extract_path_text({{ string }}, {{ "'" ~ string_path ~ "'" }})
+
 {% endmacro %}
 
 {% macro snowflake__json_extract(string, string_path) %}
 
-  json_extract_path_text(try_parse_json( {{string}} ), {{ "'" ~ string_path ~ "'" }} )
+    json_extract_path_text(try_parse_json({{ string }}), {{ "'" ~ string_path ~ "'" }})
 
 {% endmacro %}
 
 {% macro redshift__json_extract(string, string_path) %}
 
-  case when is_valid_json( {{string}} ) then json_extract_path_text({{string}}, {{ "'" ~ string_path ~ "'" }} ) else null end
- 
+    case
+        when is_valid_json({{ string }})
+        then json_extract_path_text({{ string }}, {{ "'" ~ string_path ~ "'" }})
+        else null
+    end
+
 {% endmacro %}
 
 {% macro bigquery__json_extract(string, string_path) %}
 
-  json_extract_scalar({{string}}, {{ "'$." ~ string_path ~ "'" }} )
+    json_extract_scalar({{ string }}, {{ "'$." ~ string_path ~ "'" }})
 
 {% endmacro %}
 
 {% macro postgres__json_extract(string, string_path) %}
 
-  {{string}}::json->>{{"'" ~ string_path ~ "'" }}
+    {{ string }}::json ->>{{ "'" ~ string_path ~ "'" }}
+
+{% endmacro %}
+
+
+{% macro json_extract_array(string, string_path) -%}
+
+    {{ adapter.dispatch("json_extract_array", "re_data")(string, string_path) }}
+
+{%- endmacro %}
+
+{% macro default__json_extract_array(string, string_path) %}
+
+    json_extract_array({{ string }}, {{ "'" ~ string_path ~ "'" }})
+{%- endmacro %}
+
+
+{% macro bigquery__json_extract_array(string, string_path) %}
+
+    json_extract_array({{ string }}, {{ "'$." ~ string_path ~ "'" }})
 
 {% endmacro %}

--- a/models/alerts/re_data_anomalies.sql
+++ b/models/alerts/re_data_anomalies.sql
@@ -58,7 +58,7 @@ where
         when c.metric_spec is not null
         then
             {{
-                is_anomaly_from_model(
+                is_anomaly_from_column(
                     anomaly_config="c.metric_spec",
                     last_value="z.last_value",
                     last_avg="z.last_avg",

--- a/models/alerts/re_data_anomalies.sql
+++ b/models/alerts/re_data_anomalies.sql
@@ -69,6 +69,18 @@ where
                     last_third_quartile="z.last_third_quartile",
                 )
             }}
+            and {{
+                is_anomaly_absolute_threshold(
+                    anomaly_config="c.metric_spec", last_value="z.last_value"
+                )
+            }}
+            and {{
+                is_anomaly_change_percentage(
+                    anomaly_config="c.metric_spec",
+                    last_value="z.last_value",
+                    last_avg="z.last_avg",
+                )
+            }}
         else
             {{
                 is_anomaly_from_model(

--- a/models/alerts/re_data_anomalies.sql
+++ b/models/alerts/re_data_anomalies.sql
@@ -1,8 +1,4 @@
-{{
-    config(
-        materialized='view'
-    )
-}}
+{{ config(materialized="view") }}
 select
     z.id,
     z.table_name,
@@ -11,6 +7,7 @@ select
     z.z_score_value,
     z.modified_z_score_value,
     m.anomaly_detector,
+    c.metric_spec,
     z.last_value,
     z.last_avg,
     z.last_median,
@@ -18,38 +15,72 @@ select
     z.last_median_absolute_deviation,
     z.last_mean_absolute_deviation,
     z.last_iqr,
-    z.last_first_quartile - (cast( {{ json_extract('m.anomaly_detector', 'whisker_boundary_multiplier') }} as {{numeric_type()}} ) * z.last_iqr) lower_bound,
-    z.last_third_quartile + (cast( {{ json_extract('m.anomaly_detector', 'whisker_boundary_multiplier') }} as {{numeric_type()}} ) * z.last_iqr) upper_bound,
+    z.last_first_quartile - (
+        cast(
+            {{ json_extract("m.anomaly_detector", "whisker_boundary_multiplier") }}
+            as {{ numeric_type() }}
+        )
+        * z.last_iqr
+    ) lower_bound,
+    z.last_third_quartile + (
+        cast(
+            {{ json_extract("m.anomaly_detector", "whisker_boundary_multiplier") }}
+            as {{ numeric_type() }}
+        )
+        * z.last_iqr
+    ) upper_bound,
     z.last_first_quartile,
     z.last_third_quartile,
     z.time_window_end,
     z.interval_length_sec,
     z.computed_on,
-    {{ re_data.generate_anomaly_message('z.column_name', 'z.metric', 'z.last_value', 'z.last_avg') }} as message,
-    {{ re_data.generate_metric_value_text('z.metric', 'z.last_value') }} as last_value_text
-from
-    {{ ref('re_data_z_score')}} z 
-left join {{ ref('re_data_selected') }} m 
-on {{ split_and_return_nth_value('table_name', '.', 1) }} = m.database
-and {{ split_and_return_nth_value('table_name', '.', 2) }} = m.schema
-and {{ split_and_return_nth_value('table_name', '.', 3) }} = m.name
+    {{
+        re_data.generate_anomaly_message(
+            "z.column_name", "z.metric", "z.last_value", "z.last_avg"
+        )
+    }} as message,
+    {{ re_data.generate_metric_value_text("z.metric", "z.last_value") }}
+    as last_value_text
+from {{ ref("re_data_z_score") }} z
+left join
+    {{ ref("re_data_selected") }} m
+    on {{ split_and_return_nth_value("table_name", ".", 1) }} = m.database
+    and {{ split_and_return_nth_value("table_name", ".", 2) }} = m.schema
+    and {{ split_and_return_nth_value("table_name", ".", 3) }} = m.name
+left join
+    {{ ref("re_data_selected_columns") }} c
+    on {{ split_and_return_nth_value("table_name", ".", 1) }} = c.database
+    and {{ split_and_return_nth_value("table_name", ".", 2) }} = c.schema
+    and {{ split_and_return_nth_value("table_name", ".", 3) }} = c.name
+    and z.column_name = c.column
 where
-    case when (lower(coalesce({{ json_extract('m.anomaly_detector', 'direction') }}, 'both')) = 'up' and z.last_value > z.last_avg)
-        or (lower(coalesce({{ json_extract('m.anomaly_detector', 'direction') }}, 'both')) = 'down' and z.last_value < z.last_avg)
-        or (lower(coalesce({{ json_extract('m.anomaly_detector', 'direction') }}, 'both')) != 'up' and lower(coalesce({{ json_extract('m.anomaly_detector', 'direction') }}, 'both')) != 'down')
+    case
+        when c.metric_spec is not null
         then
-            case 
-                when {{ json_extract('m.anomaly_detector', 'name') }} = 'z_score' 
-                    then abs(z_score_value) > cast({{ json_extract('m.anomaly_detector', 'threshold') }} as {{ numeric_type() }})
-                when {{ json_extract('m.anomaly_detector', 'name') }} = 'modified_z_score' 
-                    then abs(modified_z_score_value) > cast( {{ json_extract('m.anomaly_detector', 'threshold') }} as {{numeric_type()}} )
-                when {{ json_extract('m.anomaly_detector', 'name') }} = 'boxplot' 
-                    then (
-                        z.last_value < z.last_first_quartile - (cast( {{ json_extract('m.anomaly_detector', 'whisker_boundary_multiplier') }} as {{numeric_type()}} ) * z.last_iqr)
-                        or 
-                        z.last_value > z.last_third_quartile + (cast( {{ json_extract('m.anomaly_detector', 'whisker_boundary_multiplier') }} as {{numeric_type()}} ) * z.last_iqr)
-                    )
-                else false
-            end
-        else false
+            {{
+                is_anomaly_from_model(
+                    anomaly_config="'c.metric_spec'",
+                    last_value="z.last_value",
+                    last_avg="z.last_avg",
+                    z_score_value="z.z_score_value",
+                    modified_z_score_value="z.modified_z_score_value",
+                    last_first_quartile="z.last_first_quartile",
+                    last_iqr="z.last_iqr",
+                    last_third_quartile="z.last_third_quartile",
+                )
+            }}
+        else
+            {{
+                is_anomaly_from_model(
+                    anomaly_config="'m.anomaly_detector'",
+                    last_value="z.last_value",
+                    last_avg="z.last_avg",
+                    z_score_value="z.z_score_value",
+                    modified_z_score_value="z.modified_z_score_value",
+                    last_first_quartile="z.last_first_quartile",
+                    last_iqr="z.last_iqr",
+                    last_third_quartile="z.last_third_quartile",
+                )
+            }}
+
     end

--- a/models/alerts/re_data_anomalies.sql
+++ b/models/alerts/re_data_anomalies.sql
@@ -59,7 +59,7 @@ where
         then
             {{
                 is_anomaly_from_model(
-                    anomaly_config="'c.metric_spec'",
+                    anomaly_config="c.metric_spec",
                     last_value="z.last_value",
                     last_avg="z.last_avg",
                     z_score_value="z.z_score_value",
@@ -72,7 +72,7 @@ where
         else
             {{
                 is_anomaly_from_model(
-                    anomaly_config="'m.anomaly_detector'",
+                    anomaly_config="m.anomaly_detector",
                     last_value="z.last_value",
                     last_avg="z.last_avg",
                     z_score_value="z.z_score_value",

--- a/models/meta/re_data_selected.sql
+++ b/models/meta/re_data_selected.sql
@@ -1,6 +1,12 @@
-
-select 
-    name, schema, database, time_filter, metrics, columns, anomaly_detector, owners
-from {{ ref('re_data_monitored')}}
-where 
-    selected = true
+select
+    name,
+    schema,
+    database,
+    time_filter,
+    metrics,
+    additional_metrics,
+    columns,
+    anomaly_detector,
+    owners
+from {{ ref("re_data_monitored") }}
+where selected = true

--- a/models/meta/re_data_selected_columns.sql
+++ b/models/meta/re_data_selected_columns.sql
@@ -1,0 +1,33 @@
+-- depends_on: {{ ref('re_data_z_score') }}
+-- depends_on: {{ ref('re_data_selected') }}
+{% set column_metric %}
+        select distinct
+            {{ split_and_return_nth_value("table_name", ".", 1) }} as database,
+            {{ split_and_return_nth_value("table_name", ".", 2) }} as schema,
+            {{ split_and_return_nth_value("table_name", ".", 3) }} as name,
+            column_name,
+            metric
+        from {{ ref('re_data_z_score')}}
+        where column_name != ''
+{% endset %}
+{% set column_metric_details = run_query(column_metric) %}
+{% for col in column_metric_details %}
+    {% set column_name = re_data.row_value(col, "column_name") %}
+    {% set metric = re_data.row_value(col, "metric") %}
+    {% set database = re_data.row_value(col, "database") %}
+    {% set schema = re_data.row_value(col, "schema") %}
+    {% set table_name = re_data.row_value(col, "name") %}
+    {{
+        get_column_specific_anomaly(
+            database=database,
+            schema=schema,
+            column_name=column_name,
+            table_name=table_name,
+            metric_name=metric,
+        )
+    }}
+    {%- if not loop.last %}
+        union all
+    {%- endif %}
+
+{% endfor %}


### PR DESCRIPTION
## What
Have flexibility at the column level to define anomalies. 3 new features:

- define anomaly_detector on the column level, which overrides the model anomaly_detector
- have absolute thresholds for the values
- control the alerts with the change_percentage

## How
I am bringing a new model `re_data_selected_columns` that has the config per each column. When a column config is present, `re_data_anomalies` will read from `re_data_selected_columns` instead of `re_data_selected`. 
Example of column anomaly config:
```
      - name: test_data
        config:
          re_data_monitored: true
          re_data_time_filter: random_date
          re_data_anomaly_detector:
            name: z_score
            threshold: 3
          re_data_metrics_groups:
            - table_metrics
          re_data_metrics:
            column:
              price:
                - avg:
                    re_data_anomaly_detector:
                      name: z_score
                      threshold: 0.1
                      direction: both
                    absolute_threshold:
                      threshold: 5200
                      direction: up
                    change_percentage:
                      threshold: 5
                      direction: up

              customer_id:
                - distinct_values
                - avg
```
In the case above, for the avg(price) we will consider a strict z_score of 0.1 which overrides the values 3 on the model. Moreover, the values should be higher than 5200 and the percentage of change has to be higher than 5% for this to become an anomaly