### PR TITLE
Feat: warns as alerts

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,8 +18,8 @@ vars:
   re_data:time_window_start: '{{ (run_started_at - modules.datetime.timedelta(1)).strftime("%Y-%m-%d 00:00:00") }}'
   re_data:anomaly_detection_look_back_days: 30
   re_data:select: null
-
   re_data:re_data_anomalies_filtered: re_data_anomalies
+
   re_data:alerting_z_score: 3
 
   re_data:save_test_history: false

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "re_data"
-version: "0.10.8"
+version: "0.11.8"
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
@@ -22,6 +22,7 @@ vars:
   re_data:alerting_z_score: 3
 
   re_data:save_test_history: false
+  re_data:show_warns_as_alerts: false
 
   re_data:anomaly_detector:
     name: modified_z_score

--- a/models/alerts/re_data_alerts.sql
+++ b/models/alerts/re_data_alerts.sql
@@ -26,4 +26,9 @@ select
     run_at as time_window_end
 
 from {{ ref('re_data_test_history') }}
-where status = 'Fail' or status = 'Error'
+where
+    status = 'Fail'
+    or status = 'Error'
+    {% if var('re_data:show_warns_as_alerts') %}
+    or status = 'Warn'
+    {% endif %}


### PR DESCRIPTION
## What
Allows test warnings to be surfaced in the alerts model so that the alerts page in the re_data UI can list warnings as well as failures

## How
Adds a new variable `re_data:show_warns_as_alerts` (defaults to false) that when set to true will modify the SQL in the alerts model to select tests with the warn status
